### PR TITLE
AdvanceEpochs driver log

### DIFF
--- a/gossip/blockproc/decided_state.go
+++ b/gossip/blockproc/decided_state.go
@@ -40,6 +40,8 @@ type BlockState struct {
 	NextValidatorProfiles ValidatorProfiles
 
 	DirtyRules opera.Rules
+
+	AdvanceEpochs idx.Epoch
 }
 
 func (bs *BlockState) GetValidatorState(id idx.ValidatorID, validators *pos.Validators) *ValidatorBlockState {

--- a/gossip/blockproc/sealmodule/sealer.go
+++ b/gossip/blockproc/sealmodule/sealer.go
@@ -30,7 +30,8 @@ type OperaEpochsSealer struct {
 
 func (s *OperaEpochsSealer) EpochSealing() bool {
 	sealEpoch := s.bs.EpochBlocks >= s.es.Rules.Dag.MaxEpochBlocks
-	sealEpoch = sealEpoch || (s.block.Time-s.es.EpochStart) >= inter.Timestamp(s.es.Rules.Dag.MaxEpochDuration)
+	sealEpoch = sealEpoch || (s.block.Time-s.es.EpochStart) >= s.es.Rules.Dag.MaxEpochDuration
+	sealEpoch = sealEpoch || s.bs.AdvanceEpochs > 0
 	return sealEpoch || s.block.CBlock.Cheaters.Len() != 0
 }
 
@@ -86,5 +87,10 @@ func (s *OperaEpochsSealer) SealEpoch() (blockproc.BlockState, blockproc.EpochSt
 	s.bs.EpochBlocks = 0
 	newEpoch := s.es.Epoch + 1
 	s.es.Epoch = newEpoch
+
+	if s.bs.AdvanceEpochs > 0 {
+		s.bs.AdvanceEpochs--
+	}
+
 	return s.bs, s.es
 }

--- a/opera/genesis/driver/driverpos/positions.go
+++ b/opera/genesis/driver/driverpos/positions.go
@@ -19,6 +19,7 @@ var (
 		UpdateValidatorPubkey common.Hash
 		UpdateNetworkRules    common.Hash
 		UpdateNetworkVersion  common.Hash
+		AdvanceEpochs         common.Hash
 	}{
 		IncBalance:            crypto.Keccak256Hash([]byte("IncBalance(address,uint256)")),
 		SetBalance:            crypto.Keccak256Hash([]byte("SetBalance(address,uint256)")),
@@ -30,5 +31,6 @@ var (
 		UpdateValidatorPubkey: crypto.Keccak256Hash([]byte("UpdateValidatorPubkey(uint256,bytes)")),
 		UpdateNetworkRules:    crypto.Keccak256Hash([]byte("UpdateNetworkRules(bytes)")),
 		UpdateNetworkVersion:  crypto.Keccak256Hash([]byte("UpdateNetworkVersion(uint256)")),
+		AdvanceEpochs:         crypto.Keccak256Hash([]byte("AdvanceEpochs(uint256)")),
 	}
 )


### PR DESCRIPTION
- NodeDriver is authorized to fire AdvanceEpochs to force epoch sealing(s) in next block(s)