### PR TITLE
Optimization of emitter, p2p and block processing

### DIFF
--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -229,11 +229,11 @@ func lachesisMain(ctx *cli.Context) error {
 	}
 
 	// TODO: tracing flags
-	tracingStop, err := tracing.Start(ctx)
-	if err != nil {
-		return err
-	}
-	defer tracingStop()
+	//tracingStop, err := tracing.Start(ctx)
+	//if err != nil {
+	//	return err
+	//}
+	//defer tracingStop()
 
 	cfg := makeAllConfigs(ctx)
 	genesisPath := getOperaGenesis(ctx)

--- a/demo/start.sh
+++ b/demo/start.sh
@@ -24,8 +24,8 @@ do
 	--fakenet=${ACC}/$N \
 	--port=${PORT} \
 	--nat extip:127.0.0.1 \
-	--http --http.addr="127.0.0.1" --http.port=${RPCP} --http.corsdomain="*" --http.api="eth,debug,net,admin,web3,personal,txpool,ftm,sfc" \
-	--ws --ws.addr="127.0.0.1" --ws.port=${WSP} --ws.origins="*" --ws.api="eth,debug,net,admin,web3,personal,txpool,ftm,sfc" \
+	--http --http.addr="127.0.0.1" --http.port=${RPCP} --http.corsdomain="*" --http.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
+	--ws --ws.addr="127.0.0.1" --ws.port=${WSP} --ws.origins="*" --ws.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
 	--nousb --verbosity=3 --tracing &> opera$i.log)&
 
     echo -e "\tnode$i ok"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Fantom-foundation/go-opera
 go 1.14
 
 require (
-	github.com/Fantom-foundation/lachesis-base v0.0.0-20210113050827-dea8e3826660
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20191023202215-f096da5361bb // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Fantom-foundation/go-ethereum v1.9.22-ftm.0.3 h1:prAbAvXVibas58ELwl1w16oT/VvgaYYcwOcRUgtPIRA=
 github.com/Fantom-foundation/go-ethereum v1.9.22-ftm.0.3/go.mod h1:27ZY0H7YdbxCL0E/d23qHo9WCkjqnmFKHQl9UaUSw8s=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210113050827-dea8e3826660 h1:caPcRqQT1UdDKMntGVA0eYAghBCo8U3UwFrU69/mxq4=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210113050827-dea8e3826660/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0 h1:sEdaEQ/GS4vd+hc87T/ZlmZzx0jqFaWdt85c2kLO+/4=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -76,6 +76,7 @@ func (w *VerWarcher) Start() {
 	go func() {
 		defer w.wg.Done()
 		ticker := time.NewTicker(w.cfg.WarningIfNotUpgradedEvery)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"errors"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -68,6 +69,8 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	if s.stopped {
 		return errStopped
 	}
+	atomic.StoreUint32(&s.eventBusyFlag, 1)
+	defer atomic.StoreUint32(&s.eventBusyFlag, 0)
 
 	// repeat the checks under the mutex which may depend on volatile data
 	if s.store.HasEvent(e.ID()) {

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -119,6 +119,7 @@ func (env *testEnv) consensusCallbackBeginBlockFn(
 	callback := consensusCallbackBeginBlockFn(
 		env.blockProcTasks,
 		&env.blockProcWg,
+		new(uint32),
 		env.store,
 		env.blockProcModules,
 		txIndex,

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -194,10 +194,12 @@ func (em *Emitter) EmitEvent() *inter.EventPayload {
 		return nil
 	}
 
-	for _, tt := range poolTxs {
-		for _, t := range tt {
-			span := tracing.CheckTx(t.Hash(), "Emitter.EmitEvent(candidate)")
-			defer span.Finish()
+	if tracing.Enabled() {
+		for _, tt := range poolTxs {
+			for _, t := range tt {
+				span := tracing.CheckTx(t.Hash(), "Emitter.EmitEvent(candidate)")
+				defer span.Finish()
+			}
 		}
 	}
 
@@ -224,9 +226,11 @@ func (em *Emitter) EmitEvent() *inter.EventPayload {
 	em.Log.Info("New event emitted", "id", e.ID(), "parents", len(e.Parents()), "by", e.Creator(), "frame", e.Frame(), "txs", e.Txs().Len(), "t", time.Since(start))
 
 	// metrics
-	for _, t := range e.Txs() {
-		span := tracing.CheckTx(t.Hash(), "Emitter.EmitEvent()")
-		defer span.Finish()
+	if tracing.Enabled() {
+		for _, t := range e.Txs() {
+			span := tracing.CheckTx(t.Hash(), "Emitter.EmitEvent()")
+			defer span.Finish()
+		}
 	}
 
 	return e

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -44,6 +44,8 @@ type EmitterWorld struct {
 	Build    func(*inter.MutableEventPayload, func()) error
 	DagIndex *vecmt.Index
 
+	IsBusy func() bool
+
 	IsSynced func() bool
 	PeersNum func() int
 }
@@ -135,12 +137,14 @@ func (em *Emitter) Start() {
 	em.wg.Add(1)
 	go func() {
 		defer em.wg.Done()
-		ticker := time.NewTicker(21 * time.Millisecond)
+		tick := 21 * time.Millisecond
+		timer := time.NewTimer(tick)
+		defer timer.Stop()
 		for {
 			select {
 			case txNotify := <-newTxsCh:
 				em.memorizeTxTimes(txNotify.Txs)
-			case <-ticker.C:
+			case <-timer.C:
 				// track synced time
 				if em.world.PeersNum() == 0 {
 					// connected time ~= last time when it's true that "not connected yet"
@@ -150,14 +154,20 @@ func (em *Emitter) Start() {
 					// synced time ~= last time when it's true that "not synced yet"
 					em.syncStatus.p2pSynced = time.Now()
 				}
-				em.recheckChallenges()
+				if em.world.IsBusy() {
+					// Heuristic to avoid locking mutexes and hurting the concurrency
+					timer.Reset(tick / 3)
+					continue
+				}
 
+				em.recheckChallenges()
 				if time.Since(em.prevEmittedAtTime) >= em.intervals.Min {
 					_ = em.EmitEvent()
 				}
 			case <-done:
 				return
 			}
+			timer.Reset(tick)
 		}
 	}()
 }

--- a/gossip/emitter/hooks.go
+++ b/gossip/emitter/hooks.go
@@ -71,17 +71,16 @@ func (em *Emitter) OnEventConfirmed(he inter.EventI) {
 	if !em.isValidator() {
 		return
 	}
-	if he.NoTxs() {
-		return
-	}
-	e := em.world.Store.GetEventPayload(he.ID())
-	for _, tx := range e.Txs() {
-		addr, _ := types.Sender(em.world.TxSigner, tx)
-		em.originatedTxs.Dec(addr)
-	}
-	if em.pendingGas > e.GasPowerUsed() {
-		em.pendingGas -= e.GasPowerUsed()
+	if em.pendingGas > he.GasPowerUsed() {
+		em.pendingGas -= he.GasPowerUsed()
 	} else {
 		em.pendingGas = 0
+	}
+	if !he.NoTxs() {
+		e := em.world.Store.GetEventPayload(he.ID())
+		for _, tx := range e.Txs() {
+			addr, _ := types.Sender(em.world.TxSigner, tx)
+			em.originatedTxs.Dec(addr)
+		}
 	}
 }

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -108,6 +108,9 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, poolTxs map[common.Addre
 	}
 
 	maxGasUsed := em.maxGasPowerToUse(e)
+	if maxGasUsed <= e.GasPowerUsed() {
+		return
+	}
 
 	validators, epoch := em.world.Store.GetEpochValidators()
 

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -850,6 +850,7 @@ func (pm *ProtocolManager) broadcastProgress() {
 // Progress broadcast loop
 func (pm *ProtocolManager) progressBroadcastLoop() {
 	ticker := time.NewTicker(pm.config.Protocol.ProgressBroadcastPeriod)
+	defer ticker.Stop()
 	defer pm.loopsWg.Done()
 	// automatically stops if unsubscribe
 	for {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -684,11 +684,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 		}
 		if len(rawEvents) != 0 {
-			if len(rawEvents) == 1 {
-				p.EnqueueSendEventsRLP(rawEvents, ids, p.unorderedQueue)
-			} else {
-				p.EnqueueSendEventsRLP(rawEvents, ids, p.orderedQueue)
-			}
+			p.EnqueueSendEventsRLP(rawEvents, ids, p.queue)
 		}
 
 	case msg.Code == RequestEventsStream:
@@ -801,11 +797,11 @@ func (pm *ProtocolManager) BroadcastEvent(event *inter.EventPayload, passed time
 	fullBroadcast := peers[:fullRecipients]
 	hashBroadcast := peers[fullRecipients:]
 	for _, peer := range fullBroadcast {
-		peer.AsyncSendEvents(inter.EventPayloads{event}, peer.unorderedQueue)
+		peer.AsyncSendEvents(inter.EventPayloads{event}, peer.queue)
 	}
 	// Broadcast of event hash to the rest peers
 	for _, peer := range hashBroadcast {
-		peer.AsyncSendEventIDs(hash.Events{event.ID()}, peer.unorderedQueue)
+		peer.AsyncSendEventIDs(hash.Events{event.ID()}, peer.queue)
 	}
 	log.Trace("Broadcast event", "hash", id, "fullRecipients", len(fullBroadcast), "hashRecipients", len(hashBroadcast))
 	return len(peers)
@@ -826,7 +822,7 @@ func (pm *ProtocolManager) BroadcastTxs(txs types.Transactions) {
 	}
 	// FIXME include this again: peers = peers[:int(math.Sqrt(float64(len(peers))))]
 	for peer, txs := range txset {
-		peer.AsyncSendTransactions(txs, peer.unorderedQueue)
+		peer.AsyncSendTransactions(txs, peer.queue)
 	}
 }
 
@@ -847,7 +843,7 @@ func (pm *ProtocolManager) emittedBroadcastLoop() {
 func (pm *ProtocolManager) broadcastProgress() {
 	progress := pm.myProgress()
 	for _, peer := range pm.peers.List() {
-		peer.AsyncSendProgress(progress, peer.unorderedQueue)
+		peer.AsyncSendProgress(progress, peer.queue)
 	}
 }
 

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -135,6 +135,9 @@ type Service struct {
 	blockProcTasks   *workers.Workers
 	blockProcModules BlockProc
 
+	blockBusyFlag uint32
+	eventBusyFlag uint32
+
 	feed ServiceFeed
 
 	// application protocol
@@ -270,6 +273,9 @@ func (s *Service) makeEmitter(signer valkeystore.SignerI) *emitter.Emitter {
 			},
 			Build:    s.buildEvent,
 			DagIndex: s.dagIndexer,
+			IsBusy: func() bool {
+				return atomic.LoadUint32(&s.eventBusyFlag) != 0 || atomic.LoadUint32(&s.blockBusyFlag) != 0
+			},
 			IsSynced: func() bool {
 				return atomic.LoadUint32(&s.pm.synced) != 0
 			},

--- a/integration/db.go
+++ b/integration/db.go
@@ -110,6 +110,6 @@ func (p *DummyFlushableProducer) NotFlushedSizeEst() int {
 	return 0
 }
 
-func (p *DummyFlushableProducer) Flush(id []byte) error {
+func (p *DummyFlushableProducer) Flush(_ []byte) error {
 	return nil
 }

--- a/tracing/tx-tracing.go
+++ b/tracing/tx-tracing.go
@@ -19,6 +19,10 @@ func SetEnabled(val bool) {
 	enabled = val
 }
 
+func Enabled() bool {
+	return enabled
+}
+
 func StartTx(tx common.Hash, operation string) {
 	if !enabled {
 		return

--- a/utils/wgmutex/wg_mutex.go
+++ b/utils/wgmutex/wg_mutex.go
@@ -15,13 +15,11 @@ func New(m *sync.RWMutex, wg *sync.WaitGroup) *WgMutex {
 }
 
 func (m *WgMutex) Lock() {
-	m.wg.Wait() // wait once before locking for better concurrency
 	m.RWMutex.Lock()
 	m.wg.Wait()
 }
 
 func (m *WgMutex) RLock() {
-	m.wg.Wait() // wait once before locking for better concurrency
 	m.RWMutex.RLock()
 	m.wg.Wait()
 }


### PR DESCRIPTION
- optimize emitting loop. Emitter doesn't skips emitting if `busy` flag is set, which is a heuristic to prevent spending too much resources on emitting instead of processing other events
- block processing is sequential if it has no external transactions
- update lachesis-base version
- disable transactions tracing by default
- fix emitter pendingGas check
- fix ticker memory leaks
- 1 messages sending goroutine peer to reduce scheduling overhead. Previously 3 goroutines were used