### PR TITLE
Fix validators processing

### DIFF
--- a/eventcheck/gaspowercheck/gas_power_check.go
+++ b/eventcheck/gaspowercheck/gas_power_check.go
@@ -41,6 +41,7 @@ type Config struct {
 	Idx                int
 	AllocPerSec        uint64
 	MaxAllocPeriod     inter.Timestamp
+	MinEnsuredAlloc    uint64
 	StartupAllocPeriod inter.Timestamp
 	MinStartupGas      uint64
 }
@@ -150,6 +151,9 @@ func calcValidatorGasPowerPerSec(
 	perSec = validatorGasPowerPerSecBn.Uint64()
 
 	maxGasPower = perSec * (uint64(gas.MaxAllocPeriod) / uint64(time.Second))
+	if maxGasPower < gas.MinEnsuredAlloc {
+		maxGasPower = gas.MinEnsuredAlloc
+	}
 
 	startup = perSec * (uint64(gas.StartupAllocPeriod) / uint64(time.Second))
 	if startup < gas.MinStartupGas {

--- a/gossip/blockproc/decided_state.go
+++ b/gossip/blockproc/decided_state.go
@@ -17,15 +17,11 @@ type ValidatorBlockState struct {
 	Cheater          bool
 	LastEvent        hash.Event
 	Uptime           inter.Timestamp
-	LastMedianTime   inter.Timestamp
+	LastOnlineTime   inter.Timestamp
 	LastGasPowerLeft inter.GasPowerLeft
 	LastBlock        idx.Block
 	DirtyGasRefund   uint64
 	Originated       *big.Int
-}
-
-var DefaultValidatorBlockState = ValidatorBlockState{
-	Originated: new(big.Int),
 }
 
 type ValidatorEpochState struct {

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/prometheus/common/log"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc"
 	"github.com/Fantom-foundation/go-opera/inter"

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -90,7 +90,7 @@ func (p *DriverTxGenesisTransactor) PopInternalTxs(_ blockproc.BlockCtx, _ block
 	buildTx := internalTxBuilder(statedb)
 	internalTxs := make(types.Transactions, 0, 15)
 	// initialization
-	calldata := netinitcall.InitializeAll(es.Epoch, p.g.TotalSupply, sfc.ContractAddress, driverauth.ContractAddress, driver.ContractAddress, p.g.DriverOwner)
+	calldata := netinitcall.InitializeAll(es.Epoch-1, p.g.TotalSupply, sfc.ContractAddress, driverauth.ContractAddress, driver.ContractAddress, p.g.DriverOwner)
 	internalTxs = append(internalTxs, buildTx(calldata, netinit.ContractAddress))
 	// push genesis validators
 	for _, v := range p.g.Validators {

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -108,6 +108,13 @@ func (p *DriverTxGenesisTransactor) PopInternalTxs(_ blockproc.BlockCtx, _ block
 	return internalTxs
 }
 
+func maxBlockIdx(a, b idx.Block) idx.Block {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func (p *DriverTxPreTransactor) PopInternalTxs(block blockproc.BlockCtx, bs blockproc.BlockState, es blockproc.EpochState, sealing bool, statedb *state.StateDB) types.Transactions {
 	buildTx := internalTxBuilder(statedb)
 	internalTxs := make(types.Transactions, 0, 8)
@@ -129,8 +136,8 @@ func (p *DriverTxPreTransactor) PopInternalTxs(block blockproc.BlockCtx, bs bloc
 		for oldValIdx := idx.Validator(0); oldValIdx < es.Validators.Len(); oldValIdx++ {
 			info := bs.ValidatorStates[oldValIdx]
 			missed := opera.BlocksMissed{
-				BlocksNum: block.Idx - info.LastBlock,
-				Period:    inter.MaxTimestamp(block.Time, info.LastMedianTime) - info.LastMedianTime,
+				BlocksNum: maxBlockIdx(block.Idx, info.LastBlock) - info.LastBlock,
+				Period:    inter.MaxTimestamp(block.Time, info.LastOnlineTime) - info.LastOnlineTime,
 			}
 			if missed.BlocksNum <= es.Rules.Economy.BlockMissedSlack {
 				missed = opera.BlocksMissed{}
@@ -203,7 +210,13 @@ func (p *DriverTxListener) OnNewLog(l *types.Log) {
 		if weight.Sign() == 0 {
 			delete(p.bs.NextValidatorProfiles, validatorID)
 		} else {
-			profile := p.bs.NextValidatorProfiles[validatorID]
+			profile, ok := p.bs.NextValidatorProfiles[validatorID]
+			if !ok {
+				profile.PubKey = validatorpk.PubKey{
+					Type: 0,
+					Raw:  []byte{},
+				}
+			}
 			profile.Weight = weight
 			p.bs.NextValidatorProfiles[validatorID] = profile
 		}
@@ -217,7 +230,11 @@ func (p *DriverTxListener) OnNewLog(l *types.Log) {
 			return
 		}
 
-		profile := p.bs.NextValidatorProfiles[validatorID]
+		profile, ok := p.bs.NextValidatorProfiles[validatorID]
+		if !ok {
+			log.Warn("Unexpected UpdatedValidatorPubkey Driver event")
+			return
+		}
 		profile.PubKey, _ = validatorpk.FromBytes(pubkey)
 		p.bs.NextValidatorProfiles[validatorID] = profile
 	}

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -313,7 +313,7 @@ func (p *DriverTxListener) OnNewLog(l *types.Log) {
 		}
 	}
 	// Advance epochs
-	if l.Topics[0] == driverpos.Topics.UpdateNetworkRules && len(l.Data) >= 32 {
+	if l.Topics[0] == driverpos.Topics.AdvanceEpochs && len(l.Data) >= 32 {
 		// epochsNum < 2^24 to avoid overflow
 		epochsNum := new(big.Int).SetBytes(l.Data[29:32]).Uint64()
 

--- a/gossip/blockproc/eventmodule/confirmed_events_processor.go
+++ b/gossip/blockproc/eventmodule/confirmed_events_processor.go
@@ -44,11 +44,13 @@ func (p *ValidatorEventsProcessor) Finalize(block blockproc.BlockCtx) blockproc.
 			continue
 		}
 		info := p.bs.ValidatorStates[creatorIdx]
-		if block.Idx-info.LastBlock <= p.es.Rules.Economy.BlockMissedSlack {
-			info.Uptime += e.MedianTime() - info.LastMedianTime
+		if block.Idx <= info.LastBlock+p.es.Rules.Economy.BlockMissedSlack {
+			if e.MedianTime() > info.LastOnlineTime {
+				info.Uptime += e.MedianTime() - info.LastOnlineTime
+			}
 		}
 		info.LastGasPowerLeft = e.GasPowerLeft()
-		info.LastMedianTime = e.MedianTime()
+		info.LastOnlineTime = e.MedianTime()
 		info.LastBlock = p.bs.LastBlock
 		info.LastEvent = e.ID()
 		p.bs.ValidatorStates[creatorIdx] = info

--- a/gossip/blockproc/sealmodule/sealer.go
+++ b/gossip/blockproc/sealmodule/sealer.go
@@ -87,10 +87,10 @@ func (s *OperaEpochsSealer) SealEpoch() (blockproc.BlockState, blockproc.EpochSt
 		s.bs.ValidatorStates[i] = info
 	}
 
-	// dirty data becomes active
+	// dirty data become active
 	s.es.PrevEpochStart = s.es.EpochStart
 	s.es.EpochStart = s.block.Time
-	s.es.Rules = s.bs.DirtyRules
+	s.es.Rules = s.bs.DirtyRules.Copy()
 	s.es.EpochStateRoot = s.bs.FinalizedStateRoot
 
 	s.bs.EpochGas = 0

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -51,7 +51,7 @@ func (s *Service) buildEvent(e *inter.MutableEventPayload, onIndexed func()) err
 		onIndexed()
 	}
 
-	e.SetMedianTime(s.dagIndexer.MedianTime(e.ID(), s.store.GetEpochState().EpochStart) / inter.MinEventTime * inter.MinEventTime)
+	e.SetMedianTime(s.dagIndexer.MedianTime(e.ID(), s.store.GetEpochState().EpochStart))
 
 	// calc initial GasPower
 	e.SetGasPowerUsed(epochcheck.CalcGasPowerUsed(e, s.store.GetRules()))
@@ -99,7 +99,7 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 
 	// check median time
 	es := s.store.GetEpochState()
-	if e.MedianTime() != s.dagIndexer.MedianTime(e.ID(), es.EpochStart)/inter.MinEventTime*inter.MinEventTime {
+	if e.MedianTime() != s.dagIndexer.MedianTime(e.ID(), es.EpochStart) {
 		return errWrongMedianTime
 	}
 

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/eventcheck"
 	"github.com/Fantom-foundation/go-opera/eventcheck/epochcheck"
+	"github.com/Fantom-foundation/go-opera/gossip/blockproc"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
 	"github.com/Fantom-foundation/go-opera/inter"
 )
@@ -70,6 +71,39 @@ func (s *Service) buildEvent(e *inter.MutableEventPayload, onIndexed func()) err
 	return s.engine.Build(e)
 }
 
+// processSavedEvent performs processing which depends on event being saved in DB
+func (s *Service) processSavedEvent(e *inter.EventPayload, es *blockproc.EpochState) error {
+	err := s.dagIndexer.Add(e)
+	if err != nil {
+		return err
+	}
+
+	// check median time
+	if e.MedianTime() != s.dagIndexer.MedianTime(e.ID(), es.EpochStart) {
+		return errWrongMedianTime
+	}
+
+	// aBFT processing
+	return s.engine.Process(e)
+}
+
+// saveAndProcessEvent deletes event in a case if it fails validation during event processing
+func (s *Service) saveAndProcessEvent(e *inter.EventPayload, es *blockproc.EpochState) error {
+	// indexing event
+	s.store.SetEvent(e)
+	defer s.dagIndexer.DropNotFlushed()
+
+	err := s.processSavedEvent(e, es)
+	if err != nil {
+		s.store.DelEvent(e.ID())
+		return err
+	}
+
+	// save event index after success
+	s.dagIndexer.Flush()
+	return nil
+}
+
 // processEvent extends the engine.Process with gossip-specific actions on each event processing
 func (s *Service) processEvent(e *inter.EventPayload) error {
 	// s.engineMu is locked here
@@ -88,37 +122,20 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	}
 
 	oldEpoch := s.store.GetEpoch()
-
-	// indexing event
-	s.store.SetEvent(e)
-	defer s.dagIndexer.DropNotFlushed()
-	err := s.dagIndexer.Add(e)
-	if err != nil {
-		return err
-	}
-
-	// check median time
 	es := s.store.GetEpochState()
-	if e.MedianTime() != s.dagIndexer.MedianTime(e.ID(), es.EpochStart) {
-		return errWrongMedianTime
-	}
 
 	// check prev epoch hash
 	if e.PrevEpochHash() != nil {
 		if *e.PrevEpochHash() != es.Hash() {
+			s.store.DelEvent(e.ID())
 			return errWrongEpochHash
 		}
 	}
 
-	// aBFT processing
-	err = s.engine.Process(e)
+	err := s.saveAndProcessEvent(e, &es)
 	if err != nil {
-		s.store.DelEvent(e.ID())
 		return err
 	}
-
-	// save event index after success
-	s.dagIndexer.Flush()
 
 	newEpoch := s.store.GetEpoch()
 

--- a/gossip/checker_helpers.go
+++ b/gossip/checker_helpers.go
@@ -32,6 +32,7 @@ func NewGasPowerContext(s *Store, validators *pos.Validators, epoch idx.Epoch, c
 		Idx:                inter.ShortTermGas,
 		AllocPerSec:        short.AllocPerSec,
 		MaxAllocPeriod:     short.MaxAllocPeriod,
+		MinEnsuredAlloc:    cfg.Gas.MaxEventGas,
 		StartupAllocPeriod: short.StartupAllocPeriod,
 		MinStartupGas:      short.MinStartupGas,
 	}
@@ -41,6 +42,7 @@ func NewGasPowerContext(s *Store, validators *pos.Validators, epoch idx.Epoch, c
 		Idx:                inter.LongTermGas,
 		AllocPerSec:        long.AllocPerSec,
 		MaxAllocPeriod:     long.MaxAllocPeriod,
+		MinEnsuredAlloc:    cfg.Gas.MaxEventGas,
 		StartupAllocPeriod: long.StartupAllocPeriod,
 		MinStartupGas:      long.MinStartupGas,
 	}

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -306,7 +306,7 @@ func (em *Emitter) createEvent(poolTxs map[common.Address]types.Transactions) *i
 
 	mutEvent.SetParents(parents)
 	mutEvent.SetLamport(maxLamport + 1)
-	mutEvent.SetCreationTime(inter.MaxTimestamp(inter.Timestamp(time.Now().UnixNano()), selfParentTime+inter.MinEventTime))
+	mutEvent.SetCreationTime(inter.MaxTimestamp(inter.Timestamp(time.Now().UnixNano()), selfParentTime+1))
 
 	// set consensus fields
 	var metric ancestor.Metric

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -128,6 +128,11 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, poolTxs map[common.Addre
 			sorted.Pop()
 			continue
 		}
+		// check transaction is not underpriced
+		if tx.GasPrice().Cmp(em.world.Store.GetRules().Economy.MinGasPrice) < 0 {
+			sorted.Pop()
+			continue
+		}
 		// check there's enough gas power to originate the transaction
 		if tx.Gas() >= e.GasPowerLeft().Min() || e.GasPowerUsed()+tx.Gas() >= maxGasUsed {
 			sorted.Pop()

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -72,8 +72,12 @@ func (em *Emitter) memorizeTxTimes(txs types.Transactions) {
 	}
 }
 
-func getTxRoundIndex(now, txTime time.Time, validators idx.Validator) int {
-	return int((now.Sub(txTime) / TxTurnPeriod) % time.Duration(validators))
+func getTxRoundIndex(now, txTime time.Time, validatorsNum idx.Validator) int {
+	passed := now.Sub(txTime)
+	if passed < 0 {
+		passed = 0
+	}
+	return int((passed / TxTurnPeriod) % time.Duration(validatorsNum))
 }
 
 func (em *Emitter) getTxTime(txHash common.Hash) time.Time {

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -31,7 +31,11 @@ func (r *EvmStateReader) MinGasPrice() *big.Int {
 }
 
 func (r *EvmStateReader) MaxGasLimit() uint64 {
-	return (r.store.GetRules().Economy.Gas.MaxEventGas - r.store.GetRules().Economy.Gas.EventGas) * 2 / 3
+	rules := r.store.GetRules()
+	if rules.Economy.Gas.MaxEventGas < rules.Economy.Gas.EventGas {
+		return 0
+	}
+	return (rules.Economy.Gas.MaxEventGas - rules.Economy.Gas.EventGas) * 2 / 3
 }
 
 func (r *EvmStateReader) CurrentBlock() *evmcore.EvmBlock {

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -72,7 +72,7 @@ func FakeGenesisStore(num int, balance, stake *big.Int) *genesisstore.Store {
 
 	genStore.SetMetadata(genesisstore.Metadata{
 		Validators:    validators,
-		FirstEpoch:    1,
+		FirstEpoch:    2,
 		Time:          FakeGenesisTime,
 		PrevEpochTime: FakeGenesisTime - inter.Timestamp(time.Hour),
 		ExtraData:     []byte("fake"),

--- a/inter/event.go
+++ b/inter/event.go
@@ -42,8 +42,8 @@ type mutableBaseEvent struct {
 }
 
 type extEventData struct {
-	creationTime  uint64
-	medianTime    uint64
+	creationTime  Timestamp
+	medianTime    Timestamp
 	prevEpochHash *hash.Hash
 	txHash        hash.Hash
 	gasPowerLeft  GasPowerLeft
@@ -95,9 +95,9 @@ func (e *EventPayload) Size() int {
 	return e._size
 }
 
-func (e *extEventData) CreationTime() Timestamp { return Timestamp(e.creationTime * MinEventTime) }
+func (e *extEventData) CreationTime() Timestamp { return e.creationTime }
 
-func (e *extEventData) MedianTime() Timestamp { return Timestamp(e.medianTime * MinEventTime) }
+func (e *extEventData) MedianTime() Timestamp { return e.medianTime }
 
 func (e *extEventData) PrevEpochHash() *hash.Hash { return e.prevEpochHash }
 
@@ -115,9 +115,9 @@ func (e *sigData) Sig() Signature { return e.sig }
 
 func (e *payloadData) Txs() types.Transactions { return e.txs }
 
-func (e *MutableEventPayload) SetCreationTime(v Timestamp) { e.creationTime = uint64(v / MinEventTime) }
+func (e *MutableEventPayload) SetCreationTime(v Timestamp) { e.creationTime = v }
 
-func (e *MutableEventPayload) SetMedianTime(v Timestamp) { e.medianTime = uint64(v / MinEventTime) }
+func (e *MutableEventPayload) SetMedianTime(v Timestamp) { e.medianTime = v }
 
 func (e *MutableEventPayload) SetPrevEpochHash(v *hash.Hash) { e.prevEpochHash = v }
 

--- a/inter/event_serializer.go
+++ b/inter/event_serializer.go
@@ -24,7 +24,7 @@ func (e *Event) MarshalCSER(w *cser.Writer) error {
 	w.U32(uint32(e.Creator()))
 	w.U32(uint32(e.Seq()))
 	w.U32(uint32(e.Frame()))
-	w.U64(e.creationTime)
+	w.U64(uint64(e.creationTime))
 	medianTimeDiff := int64(e.creationTime) - int64(e.medianTime)
 	w.I64(medianTimeDiff)
 	// gas power
@@ -115,8 +115,8 @@ func eventUnmarshalCSER(r *cser.Reader, e *MutableEventPayload) (err error) {
 	e.SetCreator(idx.ValidatorID(creator))
 	e.SetSeq(idx.Event(seq))
 	e.SetFrame(idx.Frame(frame))
-	e.creationTime = creationTime
-	e.medianTime = uint64(int64(creationTime) - medianTimeDiff)
+	e.SetCreationTime(Timestamp(creationTime))
+	e.SetMedianTime(Timestamp(int64(creationTime) - medianTimeDiff))
 	e.SetGasPowerUsed(gasPowerUsed)
 	e.SetGasPowerLeft(GasPowerLeft{[2]uint64{gasPowerLeft0, gasPowerLeft1}})
 	e.SetParents(parents)

--- a/inter/time.go
+++ b/inter/time.go
@@ -11,10 +11,6 @@ type (
 	Timestamp uint64
 )
 
-const (
-	MinEventTime = 1e5 // 100 usec
-)
-
 // Bytes gets the byte representation of the index.
 func (t Timestamp) Bytes() []byte {
 	return bigendian.Uint64ToBytes(uint64(t))

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -6,7 +6,7 @@ func UpdateRules(src Rules, diff []byte) (res Rules, err error) {
 	changed := src
 	err = json.Unmarshal(diff, &changed)
 	if err != nil {
-		return
+		return src, err
 	}
 	// protect readonly fields
 	res = changed

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -3,7 +3,7 @@ package opera
 import "encoding/json"
 
 func UpdateRules(src Rules, diff []byte) (res Rules, err error) {
-	changed := src
+	changed := src.Copy()
 	err = json.Unmarshal(diff, &changed)
 	if err != nil {
 		return src, err

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -1,10 +1,17 @@
 package opera
 
 import (
+	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func serialize(r Rules) string {
+	b, _ := json.Marshal(&r)
+	return string(b)
+}
 
 func TestUpdateRules(t *testing.T) {
 	require := require.New(t)
@@ -15,18 +22,19 @@ func TestUpdateRules(t *testing.T) {
 	exp.Dag.MaxParents = 5
 	exp.Economy.BlockMissedSlack = 7
 	exp.Blocks.MaxBlockGas = 1000
+	exp.Economy.MinGasPrice = new(big.Int)
 	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"BlockMissedSlack":7},"Blocks":{"MaxBlockGas":1000}}`))
 	require.NoError(err)
-	require.Equal(exp, got, "mutate fields")
+	require.Equal(serialize(exp), serialize(got), "mutate fields")
 
 	exp.Dag.MaxParents = 0
 	got, err = UpdateRules(exp, []byte(`{"Name":"xxx","NetworkID":1,"Dag":{"MaxParents":0}}`))
 	require.NoError(err)
-	require.Equal(exp, got, "readonly fields")
+	require.Equal(serialize(exp), serialize(got), "readonly fields")
 
 	got, err = UpdateRules(exp, []byte(`{}`))
 	require.NoError(err)
-	require.Equal(exp, got, "empty diff")
+	require.Equal(serialize(exp), serialize(got), "empty diff")
 
 	_, err = UpdateRules(exp, []byte(`}{`))
 	require.Error(err)

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	ethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/Fantom-foundation/go-opera/inter"
 )
@@ -213,4 +214,14 @@ func FakeShortGasPowerRules() GasPowerRules {
 	config := DefaultShortGasPowerRules()
 	config.AllocPerSec *= 1000
 	return config
+}
+
+func (r Rules) Copy() Rules {
+	b, err := rlp.EncodeToBytes(r)
+	if err != nil {
+		panic("failed to copy rules")
+	}
+	cp := Rules{}
+	_ = rlp.DecodeBytes(b, &cp)
+	return cp
 }


### PR DESCRIPTION
- Fix processing of validators in blockproc modules
- Event timestamp is measured in nanoseconds. Previously it was measured in hundreds of microseconds