### PR TITLE
Hash-based transactions syncing

### DIFF
--- a/cmd/opera/launcher/import.go
+++ b/cmd/opera/launcher/import.go
@@ -140,9 +140,9 @@ func importFile(srv *gossip.Service, fn string) error {
 			return nil
 		}
 		done := make(chan struct{})
-		err := srv.DagProcessor().Enqueue("", batch.Bases(), true, time.Now(), func(_ hash.Events) error {
-			return nil
-		}, done)
+		err := srv.DagProcessor().Enqueue("", batch.Bases(), true, nil, func() {
+			done <- struct{}{}
+		})
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Fantom-foundation/go-opera
 go 1.14
 
 require (
-	github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20210127171125-ce23cadf3eb9
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20191023202215-f096da5361bb // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
@@ -38,7 +38,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
-	github.com/prometheus/common v0.7.0
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Fantom-foundation/go-ethereum v1.9.22-ftm.0.3 h1:prAbAvXVibas58ELwl1w16oT/VvgaYYcwOcRUgtPIRA=
 github.com/Fantom-foundation/go-ethereum v1.9.22-ftm.0.3/go.mod h1:27ZY0H7YdbxCL0E/d23qHo9WCkjqnmFKHQl9UaUSw8s=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0 h1:sEdaEQ/GS4vd+hc87T/ZlmZzx0jqFaWdt85c2kLO+/4=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210125055356-3ffe8de45bd0/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210127171125-ce23cadf3eb9 h1:TR2SyIrQ3/VzPF6pxNPQUH+3bN0h/vNAxfWUNiBnLb4=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210127171125-ce23cadf3eb9/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/gossip/dagfetcher"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagstream/streamleecher"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagstream/streamseeder"
+	"github.com/Fantom-foundation/lachesis-base/gossip/itemsfetcher"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
@@ -35,9 +35,14 @@ type (
 
 		Processor dagprocessor.Config
 
-		Fetcher       dagfetcher.Config
+		DagFetcher    itemsfetcher.Config
+		TxFetcher     itemsfetcher.Config
 		StreamLeecher streamleecher.Config
 		StreamSeeder  streamseeder.Config
+
+		MaxInitialTxHashesSend   int
+		MaxRandomTxHashesSend    int
+		RandomTxHashesSendPeriod time.Duration
 	}
 	// Config for the gossip service.
 	Config struct {
@@ -122,10 +127,30 @@ func DefaultConfig() Config {
 			MsgsSemaphoreTimeout:    10 * time.Second,
 			ProgressBroadcastPeriod: 10 * time.Second,
 
-			Processor:     dagprocessor.DefaultConfig(),
-			Fetcher:       dagfetcher.DefaultConfig(),
-			StreamLeecher: streamleecher.DefaultConfig(),
-			StreamSeeder:  streamseeder.DefaultConfig(),
+			Processor: dagprocessor.DefaultConfig(),
+			DagFetcher: itemsfetcher.Config{
+				ForgetTimeout:       1 * time.Minute,
+				ArriveTimeout:       1000 * time.Millisecond,
+				GatherSlack:         100 * time.Millisecond,
+				HashLimit:           20000,
+				MaxBatch:            512,
+				MaxQueuedBatches:    32,
+				MaxParallelRequests: 192,
+			},
+			TxFetcher: itemsfetcher.Config{
+				ForgetTimeout:       1 * time.Minute,
+				ArriveTimeout:       1000 * time.Millisecond,
+				GatherSlack:         100 * time.Millisecond,
+				HashLimit:           20000,
+				MaxBatch:            512,
+				MaxQueuedBatches:    32,
+				MaxParallelRequests: 64,
+			},
+			StreamLeecher:            streamleecher.DefaultConfig(),
+			StreamSeeder:             streamseeder.DefaultConfig(),
+			MaxInitialTxHashesSend:   20000,
+			MaxRandomTxHashesSend:    128,
+			RandomTxHashesSendPeriod: 20 * time.Second,
 		},
 
 		GPO: gasprice.Config{

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -875,7 +875,7 @@ func (pm *ProtocolManager) decideBroadcastAggressiveness(size int, passed time.D
 		latencyVsThroughputTradeoff = (cfg.LatencyImportance * percents) / cfg.ThroughputImportance
 	}
 
-	broadcastCost := passed * time.Duration(128 + size) / 128
+	broadcastCost := passed * time.Duration(128+size) / 128
 	broadcastAllCostTarget := time.Duration(latencyVsThroughputTradeoff) * (700 * time.Millisecond) / time.Duration(percents)
 	broadcastSqrtCostTarget := broadcastAllCostTarget * 10
 
@@ -1041,6 +1041,9 @@ func (pm *ProtocolManager) txBroadcastLoop() {
 			return
 
 		case <-ticker.C:
+			if atomic.LoadUint32(&pm.synced) == 0 {
+				continue
+			}
 			peers := pm.peers.List()
 			if len(peers) == 0 {
 				continue

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -601,7 +601,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 
 	// Handle the message depending on its contents
 	switch {
-	case msg.Code == EthStatusMsg:
+	case msg.Code == HandshakeMsg:
 		// Status messages should never arrive after the handshake
 		return errResp(ErrExtraStatusMsg, "uncontrolled status message")
 
@@ -640,7 +640,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		_ = pm.fetcher.NotifyReceived(events.IDs())
 		pm.handleEvents(p, events.Bases(), events.Len() >= softLimitItems/2)
 
-	case msg.Code == EvmTxMsg:
+	case msg.Code == EvmTxsMsg:
 		// Transactions arrived, make sure we have a valid and fresh graph to handle them
 		if atomic.LoadUint32(&pm.synced) == 0 {
 			break

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -875,10 +875,9 @@ func (pm *ProtocolManager) decideBroadcastAggressiveness(size int, passed time.D
 		latencyVsThroughputTradeoff = (cfg.LatencyImportance * percents) / cfg.ThroughputImportance
 	}
 
-	byteCost := time.Millisecond / 2
-	broadcastCost := passed + time.Duration(size)*byteCost
+	broadcastCost := passed * time.Duration(128 + size) / 128
 	broadcastAllCostTarget := time.Duration(latencyVsThroughputTradeoff) * (700 * time.Millisecond) / time.Duration(percents)
-	broadcastSqrtCostTarget := broadcastAllCostTarget * 20
+	broadcastSqrtCostTarget := broadcastAllCostTarget * 10
 
 	fullRecipients := 0
 	if latencyVsThroughputTradeoff >= maxPercents {

--- a/gossip/handler_fuzz.go
+++ b/gossip/handler_fuzz.go
@@ -116,8 +116,8 @@ func newFuzzMsg(data []byte) (*p2p.Msg, error) {
 
 	var (
 		codes = []uint64{
-			EthStatusMsg,
-			EvmTxMsg,
+			HandshakeMsg,
+			EvmTxsMsg,
 			ProgressMsg,
 			NewEventIDsMsg,
 			GetEventsMsg,

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -37,9 +37,9 @@ const (
 	// (based on peer's epoch).
 	ProgressMsg = 1
 
-	EvmTxsMsg      = 2
-	EvmTxHashesMsg = 3
-	GetEvmTxsMsg   = 4
+	EvmTxsMsg         = 2
+	NewEvmTxHashesMsg = 3
+	GetEvmTxsMsg      = 4
 
 	// Non-aggressive events propagation. Signals about newly-connected
 	// batch of events, sending only their IDs.
@@ -101,6 +101,11 @@ type txPool interface {
 	// SubscribeNewTxsNotify should return an event subscription of
 	// NewTxsNotify and send events to the given channel.
 	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
+
+	Get(common.Hash) *types.Transaction
+
+	OnlyNotExisting(hashes []common.Hash) []common.Hash
+	SampleHashes(max int) []common.Hash
 }
 
 // handshakeData is the network packet for the initial handshake message

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -1,8 +1,6 @@
 package gossip
 
 import (
-	"math/big"
-
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
@@ -31,32 +29,32 @@ const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a prot
 
 // protocol message codes
 const (
-	// Protocol messages belonging to eth/62
-	EthStatusMsg = 0x00
-	EvmTxMsg     = 0x02
-
-	// Protocol messages belonging to opera/62
+	HandshakeMsg = 0
 
 	// Signals about the current synchronization status.
 	// The current peer's status is used during packs downloading,
 	// and to estimate may peer be interested in the new event or not
 	// (based on peer's epoch).
-	ProgressMsg = 0xf0
+	ProgressMsg = 1
+
+	EvmTxsMsg      = 2
+	EvmTxHashesMsg = 3
+	GetEvmTxsMsg   = 4
 
 	// Non-aggressive events propagation. Signals about newly-connected
 	// batch of events, sending only their IDs.
-	NewEventIDsMsg = 0xf1
+	NewEventIDsMsg = 5
 
 	// Request the batch of events by IDs
-	GetEventsMsg = 0xf2
+	GetEventsMsg = 6
 	// Contains the batch of events.
 	// May be an answer to GetEventsMsg, or be sent during aggressive events propagation.
-	EventsMsg = 0xf3
+	EventsMsg = 7
 
 	// Request a range of events by a selector
-	RequestEventsStream = 0xf4
+	RequestEventsStream = 8
 	// Contains the requested events by RequestEventsStream
-	EventsStreamResponse = 0xf5
+	EventsStreamResponse = 9
 )
 
 type errCode int
@@ -105,13 +103,11 @@ type txPool interface {
 	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
 }
 
-// ethStatusData is the network packet for the status message. It's used for compatibility with some ETH wallets.
-type ethStatusData struct {
-	ProtocolVersion   uint32
-	NetworkID         uint64
-	DummyTD           *big.Int
-	DummyCurrentBlock common.Hash
-	Genesis           common.Hash
+// handshakeData is the network packet for the initial handshake message
+type handshakeData struct {
+	ProtocolVersion uint32
+	NetworkID       uint64
+	Genesis         common.Hash
 }
 
 // PeerProgress is synchronization status of a peer


### PR DESCRIPTION
- Add txpool transactions fetching by hashes to decrease bandwidth usage for transactions syncing
- Add periodic syncing of random subsets of txpool transaction hashes. By default, 128 random txpool transaction hashes are sent every 20s to a random peer. It ensures that every peer will get every transaction over time
- Optimize broadcast aggressiveness heuristic (ProtocolManager.decideBroadcastAggressiveness)