### PR TITLE
Larger epochs

### DIFF
--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -109,6 +109,7 @@ func init() {
 		utils.GpoMaxGasPriceFlag,
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,
+		utils.LightKDFFlag,
 		configFileFlag,
 		validatorIDFlag,
 		validatorPubkeyFlag,

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -164,6 +164,7 @@ func DefaultConfig() Config {
 			WarningIfNotUpgradedEvery: 5 * time.Second,
 		},
 	}
+	cfg.Protocol.StreamLeecher.MaxSessionRestart = 4 * time.Minute
 
 	return cfg
 }
@@ -214,7 +215,7 @@ func DefaultStoreConfig() StoreConfig {
 			BlocksSize:       512 * opt.KiB,
 		},
 		EVM:                 evmstore.DefaultStoreConfig(),
-		MaxNonFlushedSize:   16 * opt.MiB,
+		MaxNonFlushedSize:   22 * opt.MiB,
 		MaxNonFlushedPeriod: 30 * time.Minute,
 	}
 }
@@ -230,7 +231,7 @@ func LiteStoreConfig() StoreConfig {
 			BlocksSize:       50 * opt.KiB,
 		},
 		EVM:                 evmstore.LiteStoreConfig(),
-		MaxNonFlushedSize:   400 * opt.KiB,
+		MaxNonFlushedSize:   800 * opt.KiB,
 		MaxNonFlushedPeriod: 30 * time.Minute,
 	}
 }

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -139,7 +139,7 @@ func (s *Store) IsCommitNeeded(epochSealing bool) bool {
 
 // capEVM cache if exceeds maximum RAM limit.
 func (s *Store) capEVM() {
-	s.evm.Cap(s.cfg.MaxNonFlushedSize/2, s.cfg.MaxNonFlushedSize/4)
+	s.evm.Cap(s.cfg.MaxNonFlushedSize/3, s.cfg.MaxNonFlushedSize/4)
 }
 
 // Commit changes.

--- a/integration/bench_db_flush_test.go
+++ b/integration/bench_db_flush_test.go
@@ -1,0 +1,92 @@
+package integration
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/abft"
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/leveldb"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+
+	"github.com/Fantom-foundation/go-opera/gossip"
+	"github.com/Fantom-foundation/go-opera/integration/makegenesis"
+	"github.com/Fantom-foundation/go-opera/inter"
+	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
+	"github.com/Fantom-foundation/go-opera/utils"
+	"github.com/Fantom-foundation/go-opera/vecmt"
+)
+
+func BenchmarkFlushDBs(b *testing.B) {
+	rawProducer, dir := dbProducer("flush_bench")
+	defer os.RemoveAll(dir)
+	genStore := makegenesis.FakeGenesisStore(1, utils.ToFtm(1), utils.ToFtm(1))
+	_, _, store, s2, s3, _ := MakeEngine(rawProducer, InputGenesis{
+		Hash: genStore.Hash(),
+		Read: func(store *genesisstore.Store) error {
+			buf := bytes.NewBuffer(nil)
+			err := genStore.Export(buf)
+			if err != nil {
+				return err
+			}
+			return store.Import(buf)
+		},
+		Close: func() error {
+			return nil
+		},
+	}, Configs{
+		Opera:         gossip.DefaultConfig(),
+		OperaStore:    gossip.DefaultStoreConfig(),
+		Lachesis:      abft.DefaultConfig(),
+		LachesisStore: abft.DefaultStoreConfig(),
+		VectorClock:   vecmt.DefaultConfig(),
+	})
+	defer store.Close()
+	defer s2.Close()
+	defer s3.Close()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := idx.Block(0)
+		randUint32s := func() []uint32 {
+			arr := make([]uint32, 128)
+			for i := 0; i < len(arr); i++ {
+				arr[i] = uint32(i) ^ (uint32(n) << 16) ^ 0xd0ad884e
+			}
+			return []uint32{uint32(n), uint32(n) + 1, uint32(n) + 2}
+		}
+		for !store.IsCommitNeeded(false) {
+			store.SetBlock(n, &inter.Block{
+				Time:        inter.Timestamp(n << 32),
+				Atropos:     hash.Event{},
+				Events:      hash.Events{},
+				Txs:         []common.Hash{},
+				InternalTxs: []common.Hash{},
+				SkippedTxs:  randUint32s(),
+				GasUsed:     uint64(n) << 24,
+				Root:        hash.Hash{},
+			})
+			n++
+		}
+		err := store.Commit()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func cache64mb(string) int {
+	return 64 * opt.MiB
+}
+
+func dbProducer(name string) (kvdb.IterableDBProducer, string) {
+	dir, err := ioutil.TempDir("", name)
+	if err != nil {
+		panic(err)
+	}
+	return leveldb.NewProducer(dir, cache64mb), dir
+}

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -174,7 +174,7 @@ func DefaultDagRules() DagRules {
 
 func DefaultEpochsRules() EpochsRules {
 	return EpochsRules{
-		MaxEpochGas:      420000000,
+		MaxEpochGas:      1500000000,
 		MaxEpochDuration: inter.Timestamp(4 * time.Hour),
 	}
 }


### PR DESCRIPTION
- raise epoch gas limit from 420000000 to 1500000000
- adjust the default configs for better performance on larger epochs