### PR TITLE
No discovery v5

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/naoina/toml"
 	"gopkg.in/urfave/cli.v1"
@@ -171,12 +171,12 @@ func getOperaGenesis(ctx *cli.Context) integration.InputGenesis {
 func setBootnodes(ctx *cli.Context, urls []string, cfg *node.Config) {
 	for _, url := range urls {
 		if url != "" {
-			node, err := discv5.ParseNode(url)
+			node, err := enode.ParseV4(url)
 			if err != nil {
 				log.Error("Bootstrap URL invalid", "enode", url, "err", err)
 				continue
 			}
-			cfg.P2P.BootstrapNodesV5 = append(cfg.P2P.BootstrapNodesV5, node)
+			cfg.P2P.BootstrapNodes = append(cfg.P2P.BootstrapNodes, node)
 		}
 	}
 }

--- a/cmd/opera/launcher/defaults.go
+++ b/cmd/opera/launcher/defaults.go
@@ -46,7 +46,7 @@ var NodeDefaultConfig = node.Config{
 	GraphQLVirtualHosts: []string{"localhost"},
 	P2P: p2p.Config{
 		NoDiscovery: false, // enable discovery v4 by default
-		DiscoveryV5: true,  // enable discovery v5 by default
+		DiscoveryV5: false, // disable discovery v5 by default
 		ListenAddr:  fmt.Sprintf(":%d", DefaultP2PPort),
 		MaxPeers:    50,
 		NAT:         nat.Any(),

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -216,8 +216,6 @@ func init() {
 }
 
 func Launch(args []string) error {
-	overrideFlags()
-	overrideParams()
 	return app.Run(args)
 }
 


### PR DESCRIPTION
Disabled discovery v5 by default according to [recommendations](https://github.com/ethereum/go-ethereum/blob/v1.9.25/p2p/discv5/README) and memory leaks research results.