### PR TITLE
topicsdb index by block number

### DIFF
--- a/topicsdb/key.go
+++ b/topicsdb/key.go
@@ -2,7 +2,6 @@ package topicsdb
 
 import (
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -44,20 +43,6 @@ func (id *ID) TxHash() (tx common.Hash) {
 func (id *ID) Index() uint {
 	return uint(bytesToUint(
 		(*id)[uint64Size+hashSize : uint64Size+hashSize+uint64Size]))
-}
-
-func blocksMask(from, to idx.Block) []byte {
-	a := uintToBytes(uint64(from))
-	b := uintToBytes(uint64(to))
-
-	mask := make([]byte, 0, uint64Size)
-	for i, ai := range a {
-		if ai != b[i] {
-			break
-		}
-		mask = append(mask, ai)
-	}
-	return mask
 }
 
 func topicKey(topic common.Hash, pos uint8, logrec ID) []byte {

--- a/topicsdb/key.go
+++ b/topicsdb/key.go
@@ -70,15 +70,6 @@ func topicKey(topic common.Hash, pos uint8, logrec ID) []byte {
 	return key
 }
 
-func otherKey(logrec ID, pos uint8) []byte {
-	key := make([]byte, 0, otherKeySize)
-
-	key = append(key, logrec.Bytes()...)
-	key = append(key, posToBytes(pos)...)
-
-	return key
-}
-
 func posToBytes(pos uint8) []byte {
 	return []byte{pos}
 }
@@ -100,16 +91,6 @@ func extractLogrecID(key []byte) (id ID) {
 	case topicKeySize:
 		copy(id[:], key[hashSize+uint8Size:])
 		return
-	default:
-		panic("wrong key type")
-	}
-}
-
-func extractTopicPos(key []byte) uint8 {
-	switch len(key) {
-	case otherKeySize:
-		return bytesToPos(
-			key[logrecKeySize : logrecKeySize+uint8Size])
 	default:
 		panic("wrong key type")
 	}

--- a/topicsdb/key.go
+++ b/topicsdb/key.go
@@ -2,6 +2,7 @@ package topicsdb
 
 import (
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -45,9 +46,9 @@ func (id *ID) Index() uint {
 		(*id)[uint64Size+hashSize : uint64Size+hashSize+uint64Size]))
 }
 
-func blocksMask(from, to uint64) []byte {
-	a := uintToBytes(from)
-	b := uintToBytes(to)
+func blocksMask(from, to idx.Block) []byte {
+	a := uintToBytes(uint64(from))
+	b := uintToBytes(uint64(to))
 
 	mask := make([]byte, 0, uint64Size)
 	for i, ai := range a {

--- a/topicsdb/key.go
+++ b/topicsdb/key.go
@@ -45,6 +45,20 @@ func (id *ID) Index() uint {
 		(*id)[uint64Size+hashSize : uint64Size+hashSize+uint64Size]))
 }
 
+func blocksMask(from, to uint64) []byte {
+	a := uintToBytes(from)
+	b := uintToBytes(to)
+
+	mask := make([]byte, 0, uint64Size)
+	for i, ai := range a {
+		if ai != b[i] {
+			break
+		}
+		mask = append(mask, ai)
+	}
+	return mask
+}
+
 func topicKey(topic common.Hash, pos uint8, logrec ID) []byte {
 	key := make([]byte, 0, topicKeySize)
 

--- a/topicsdb/key_test.go
+++ b/topicsdb/key_test.go
@@ -3,28 +3,23 @@ package topicsdb
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPosToBytes(t *testing.T) {
-	assertar := assert.New(t)
+	require := require.New(t)
 
-	for expect := uint8(0); ; /*see break*/ expect += 0x0f {
+	for i := 0xff / 0x0f; i >= 0; i-- {
+		expect := uint8(0x0f * i)
 		bb := posToBytes(expect)
 		got := bytesToPos(bb)
 
-		if !assertar.Equal(expect, got) {
-			return
-		}
-
-		if expect == 0xff {
-			break
-		}
+		require.Equal(expect, got)
 	}
 }
 
 func TestBlocksMask(t *testing.T) {
-	assertar := assert.New(t)
+	require := require.New(t)
 
 	for i, tt := range []struct {
 		from uint64
@@ -38,6 +33,6 @@ func TestBlocksMask(t *testing.T) {
 	} {
 		exp := tt.mask
 		got := blocksMask(tt.from, tt.to)
-		assertar.Equal(exp, got, i)
+		require.Equal(exp, got, i)
 	}
 }

--- a/topicsdb/key_test.go
+++ b/topicsdb/key_test.go
@@ -3,6 +3,7 @@ package topicsdb
 import (
 	"testing"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,8 +23,8 @@ func TestBlocksMask(t *testing.T) {
 	require := require.New(t)
 
 	for i, tt := range []struct {
-		from uint64
-		to   uint64
+		from idx.Block
+		to   idx.Block
 		mask []byte
 	}{
 		{0x00110021, 0x00110022, []byte{0, 0, 0, 0, 0x00, 0x11, 0x00}},

--- a/topicsdb/key_test.go
+++ b/topicsdb/key_test.go
@@ -22,3 +22,22 @@ func TestPosToBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestBlocksMask(t *testing.T) {
+	assertar := assert.New(t)
+
+	for i, tt := range []struct {
+		from uint64
+		to   uint64
+		mask []byte
+	}{
+		{0x00110021, 0x00110022, []byte{0, 0, 0, 0, 0x00, 0x11, 0x00}},
+		{0x00110022, 0x00110020, []byte{0, 0, 0, 0, 0x00, 0x11, 0x00}},
+		{0, 0x0000000000000000, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{0, 0xffffffffffffffff, []byte{}},
+	} {
+		exp := tt.mask
+		got := blocksMask(tt.from, tt.to)
+		assertar.Equal(exp, got, i)
+	}
+}

--- a/topicsdb/key_test.go
+++ b/topicsdb/key_test.go
@@ -3,7 +3,6 @@ package topicsdb
 import (
 	"testing"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,24 +15,5 @@ func TestPosToBytes(t *testing.T) {
 		got := bytesToPos(bb)
 
 		require.Equal(expect, got)
-	}
-}
-
-func TestBlocksMask(t *testing.T) {
-	require := require.New(t)
-
-	for i, tt := range []struct {
-		from idx.Block
-		to   idx.Block
-		mask []byte
-	}{
-		{0x00110021, 0x00110022, []byte{0, 0, 0, 0, 0x00, 0x11, 0x00}},
-		{0x00110022, 0x00110020, []byte{0, 0, 0, 0, 0x00, 0x11, 0x00}},
-		{0, 0x0000000000000000, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
-		{0, 0xffffffffffffffff, []byte{}},
-	} {
-		exp := tt.mask
-		got := blocksMask(tt.from, tt.to)
-		require.Equal(exp, got, i)
 	}
 }

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -5,14 +5,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func (tt *Index) fetchLazy(topics [][]common.Hash, blocksMask []byte, onLog func(*types.Log) bool) (err error) {
-	_, err = tt.walk(nil, blocksMask, topics, 0, onLog)
+func (tt *Index) fetchLazy(topics [][]common.Hash, blockStart []byte, onLog func(*types.Log) bool) (err error) {
+	_, err = tt.walk(nil, blockStart, topics, 0, onLog)
 	return
 }
 
 // walk for topics recursive.
 func (tt *Index) walk(
-	rec *logrec, blocksMask []byte, topics [][]common.Hash, pos uint8, onLog func(*types.Log) bool,
+	rec *logrec, blockStart []byte, topics [][]common.Hash, pos uint8, onLog func(*types.Log) bool,
 ) (
 	gonext bool, err error,
 ) {
@@ -51,12 +51,9 @@ func (tt *Index) walk(
 		if rec != nil {
 			copy(prefix[prefLen:], rec.ID.Bytes())
 			prefLen += logrecKeySize
-		} else {
-			copy(prefix[prefLen:], blocksMask)
-			prefLen += len(blocksMask)
 		}
 
-		it := tt.table.Topic.NewIterator(prefix[:prefLen], nil)
+		it := tt.table.Topic.NewIterator(prefix[:prefLen], blockStart)
 		for it.Next() {
 			id := extractLogrecID(it.Key())
 			topicCount := bytesToPos(it.Value())

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -10,6 +10,7 @@ func (tt *Index) fetchLazy(topics [][]common.Hash, blocksMask []byte, onLog func
 	return
 }
 
+// walk for topics recursive.
 func (tt *Index) walk(
 	rec *logrec, blocksMask []byte, topics [][]common.Hash, pos uint8, onLog func(*types.Log) bool,
 ) (
@@ -17,6 +18,7 @@ func (tt *Index) walk(
 ) {
 	gonext = true
 	for {
+		// Max recursion depth is equal to len(topics) and limited by MaxCount.
 		if pos >= uint8(len(topics)) {
 			if rec == nil {
 				return

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -25,7 +25,7 @@ func (tt *Index) walk(
 			}
 
 			var r *types.Log
-			r, err = rec.FetchLog(tt.table.Other, tt.table.Logrec)
+			r, err = rec.FetchLog(tt.table.Logrec)
 			if err != nil {
 				return
 			}

--- a/topicsdb/search_test.go
+++ b/topicsdb/search_test.go
@@ -35,7 +35,6 @@ func BenchmarkSearch(b *testing.B) {
 	}
 
 	b.Run("Lazy", func(b *testing.B) {
-		// db.fetchMethod = db.fetchLazy
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -52,11 +52,11 @@ func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext 
 	}
 
 	ok := false
-	for _, alternative := range topics {
-		if len(alternative) > MaxCount {
+	for _, variants := range topics {
+		if len(variants) > MaxCount {
 			return ErrTooManyTopics
 		}
-		ok = ok || len(alternative) > 0
+		ok = ok || len(variants) > 0
 	}
 	if !ok {
 		return ErrEmptyTopics

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -44,7 +44,7 @@ func New(db kvdb.Store) *Index {
 // ForEach matches log records by topics. 1st topics element is an address.
 func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
 	if err := checkTopics(topics); err != nil {
-		return nil
+		return err
 	}
 
 	return tt.fetchLazy(topics, nil, onLog)
@@ -53,7 +53,7 @@ func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext 
 // ForEachInBlocks matches log records of block range by topics. 1st topics element is an address.
 func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
 	if err := checkTopics(topics); err != nil {
-		return nil
+		return err
 	}
 
 	bm := blocksMask(blockFrom, blockTo)

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -52,15 +52,14 @@ func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext 
 
 // ForEachInBlocks matches log records of block range by topics. 1st topics element is an address.
 func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
+	if blockFrom > blockTo {
+		return nil
+	}
+
 	if err := checkTopics(topics); err != nil {
 		return err
 	}
 
-	bm := blocksMask(blockFrom, blockTo)
-
-	if blockFrom > blockTo {
-		blockFrom, blockTo = blockTo, blockFrom
-	}
 	moreAccurate := func(l *types.Log) (gonext bool) {
 		if blockFrom > l.BlockNumber || l.BlockNumber > blockTo {
 			return true
@@ -68,6 +67,7 @@ func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Ha
 		return onLog(l)
 	}
 
+	bm := blocksMask(blockFrom, blockTo)
 	return tt.fetchLazy(topics, bm, moreAccurate)
 }
 

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -28,8 +28,6 @@ type Index struct {
 		// (blockN+TxHash+logIndex) -> blockHash, data
 		Logrec kvdb.Store `table:"r"`
 	}
-
-	fetchMethod func(topics [][]common.Hash, onLog func(*types.Log) (next bool)) error
 }
 
 // New Index instance.
@@ -37,8 +35,6 @@ func New(db kvdb.Store) *Index {
 	tt := &Index{
 		db: db,
 	}
-
-	tt.fetchMethod = tt.fetchLazy
 
 	table.MigrateTables(&tt.table, tt.db)
 
@@ -62,7 +58,7 @@ func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext 
 		return ErrEmptyTopics
 	}
 
-	return tt.fetchMethod(topics, onLog)
+	return tt.fetchLazy(topics, onLog)
 }
 
 // MustPush calls Write() and panics if error.

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -62,14 +62,13 @@ func (tt *Index) ForEachInBlocks(from, to idx.Block, topics [][]common.Hash, onL
 	}
 
 	moreAccurate := func(l *types.Log) (gonext bool) {
-		if uint64(from) > l.BlockNumber || l.BlockNumber > uint64(to) {
-			return true
+		if l.BlockNumber > uint64(to) {
+			return false
 		}
 		return onLog(l)
 	}
 
-	bm := blocksMask(from, to)
-	return tt.fetchLazy(topics, bm, moreAccurate)
+	return tt.fetchLazy(topics, uintToBytes(uint64(from)), moreAccurate)
 }
 
 func checkTopics(topics [][]common.Hash) error {

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-const MaxCount = 0xff
+const MaxTopicsCount = 0xff
 
 var (
 	ErrTooManyTopics = fmt.Errorf("Too many topics")
@@ -72,13 +72,13 @@ func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Ha
 }
 
 func checkTopics(topics [][]common.Hash) error {
-	if len(topics) > MaxCount {
+	if len(topics) > MaxTopicsCount {
 		return ErrTooManyTopics
 	}
 
 	ok := false
 	for _, variants := range topics {
-		if len(variants) > MaxCount {
+		if len(variants) > MaxTopicsCount {
 			return ErrTooManyTopics
 		}
 		ok = ok || len(variants) > 0
@@ -101,7 +101,7 @@ func (tt *Index) MustPush(recs ...*types.Log) {
 // Write log record to database.
 func (tt *Index) Push(recs ...*types.Log) error {
 	for _, rec := range recs {
-		if len(rec.Topics) > MaxCount {
+		if len(rec.Topics) > MaxTopicsCount {
 			return ErrTooManyTopics
 		}
 		count := posToBytes(uint8(1 + len(rec.Topics)))

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -3,6 +3,7 @@ package topicsdb
 import (
 	"fmt"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
 
@@ -51,8 +52,8 @@ func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext 
 }
 
 // ForEachInBlocks matches log records of block range by topics. 1st topics element is an address.
-func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
-	if blockFrom > blockTo {
+func (tt *Index) ForEachInBlocks(from, to idx.Block, topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
+	if from > to {
 		return nil
 	}
 
@@ -61,13 +62,13 @@ func (tt *Index) ForEachInBlocks(blockFrom, blockTo uint64, topics [][]common.Ha
 	}
 
 	moreAccurate := func(l *types.Log) (gonext bool) {
-		if blockFrom > l.BlockNumber || l.BlockNumber > blockTo {
+		if uint64(from) > l.BlockNumber || l.BlockNumber > uint64(to) {
 			return true
 		}
 		return onLog(l)
 	}
 
-	bm := blocksMask(blockFrom, blockTo)
+	bm := blocksMask(from, to)
 	return tt.fetchLazy(topics, bm, moreAccurate)
 }
 

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -53,7 +53,7 @@ func TestIndexSearchMultyVariants(t *testing.T) {
 		Address:     addr1,
 		Topics:      []common.Hash{hash1, hash1, hash1},
 	}, {
-		BlockNumber: 2,
+		BlockNumber: 3,
 		Address:     addr2,
 		Topics:      []common.Hash{hash2, hash2, hash2},
 	}, {
@@ -117,7 +117,7 @@ func TestIndexSearchMultyVariants(t *testing.T) {
 
 	t.Run("With by blocks", func(t *testing.T) {
 		require := require.New(t)
-		got, err := index.FindInBlocks(500, 999, [][]common.Hash{
+		got, err := index.FindInBlocks(2, 998, [][]common.Hash{
 			{addr1.Hash(), addr2.Hash(), addr3.Hash(), addr4.Hash()},
 			{hash1, hash2, hash3, hash4},
 			{},

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -25,8 +26,8 @@ func (tt *Index) Find(topics [][]common.Hash) (all []*types.Log, err error) {
 }
 
 // FindInBlocks wraps ForEachInBlocks() for tests.
-func (tt *Index) FindInBlocks(blockFrom, blockTo uint64, topics [][]common.Hash) (all []*types.Log, err error) {
-	err = tt.ForEachInBlocks(blockFrom, blockTo, topics, func(item *types.Log) (next bool) {
+func (tt *Index) FindInBlocks(from, to idx.Block, topics [][]common.Hash) (all []*types.Log, err error) {
+	err = tt.ForEachInBlocks(from, to, topics, func(item *types.Log) (next bool) {
 		all = append(all, item)
 		next = true
 		return


### PR DESCRIPTION
New topicsdb/Index.ForEachInBlocks() method iterates by logs of block range only.
Changes kvdb store struct, is not compatible with prev db.