### PR TITLE
Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all: opera
 
 .PHONY: opera
 opera:
-	GIT_COMMIT=`git rev-list -1 HEAD` && \
-	GIT_DATE=`git log -1 --date=short --pretty=format:%ct` && \
+	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
+	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	go build \
 	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/cmd/opera/launcher.gitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/cmd/opera/launcher.gitDate=$${GIT_DATE}" \
 	    -o build/opera \


### PR DESCRIPTION
Makefile update allows to build opera without information from version control system (git commit hash and date).
Resolves #49 .