### PR TITLE
Logs filter refactor

### DIFF
--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -131,7 +131,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 }
 
 // indexedLogs returns the logs matching the filter criteria based on topics index.
-func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) (logs []*types.Log, err error) {
+func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) ([]*types.Log, error) {
 	addresses := make([]common.Hash, len(f.addresses))
 	for i, addr := range f.addresses {
 		addresses[i] = addr.Hash()
@@ -141,17 +141,9 @@ func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) (logs []
 	pattern[0] = addresses
 	pattern = append(pattern, f.topics...)
 
-	err = f.backend.EvmLogIndex().ForEachInBlocks(
-		begin, end, pattern,
-		func(l *types.Log) bool {
-			logs = append(logs, l)
-			return true
-		})
-	if err != nil {
-		return
-	}
+	logs, err := f.backend.EvmLogIndex().FindInBlocks(begin, end, pattern)
 
-	return
+	return logs, err
 }
 
 // indexedLogs returns the logs matching the filter criteria based on raw block

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -141,7 +141,7 @@ func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) ([]*type
 	pattern[0] = addresses
 	pattern = append(pattern, f.topics...)
 
-	logs, err := f.backend.EvmLogIndex().FindInBlocks(begin, end, pattern)
+	logs, err := f.backend.EvmLogIndex().FindInBlocks(ctx, begin, end, pattern)
 
 	return logs, err
 }

--- a/gossip/sfcapi/process.go
+++ b/gossip/sfcapi/process.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ApplyGenesis(s *Store, index *topicsdb.Index) {
-	_ = index.ForEach([][]common.Hash{{sfc.ContractAddress.Hash()}, {Topics.ClaimedValidatorReward, Topics.ClaimedDelegationReward}}, func(l *types.Log) (gonext bool) {
+	_ = index.ForEach(nil, [][]common.Hash{{sfc.ContractAddress.Hash()}, {Topics.ClaimedValidatorReward, Topics.ClaimedDelegationReward}}, func(l *types.Log) (gonext bool) {
 		if l.Topics[0] == Topics.ClaimedValidatorReward && len(l.Topics) > 1 && len(l.Data) >= 32 {
 			stakerID := idx.ValidatorID(new(big.Int).SetBytes(l.Topics[1][:]).Uint64())
 			reward := new(big.Int).SetBytes(l.Data[0:32])

--- a/topicsdb/record.go
+++ b/topicsdb/record.go
@@ -10,6 +10,8 @@ type (
 	logrec struct {
 		ID          ID
 		topicsCount uint8
+		result      *types.Log
+		err         error
 	}
 )
 
@@ -20,11 +22,11 @@ func newLogrec(rec ID, topicCount uint8) *logrec {
 	}
 }
 
-// FetchLog record's data.
-func (rec *logrec) FetchLog(
+// fetch record's data.
+func (rec *logrec) fetch(
 	logrecTable kvdb.Reader,
-) (r *types.Log, err error) {
-	r = &types.Log{
+) {
+	r := &types.Log{
 		BlockNumber: rec.ID.BlockNumber(),
 		TxHash:      rec.ID.TxHash(),
 		Index:       rec.ID.Index(),
@@ -35,8 +37,8 @@ func (rec *logrec) FetchLog(
 		buf    []byte
 		offset int
 	)
-	buf, err = logrecTable.Get(rec.ID.Bytes())
-	if err != nil {
+	buf, rec.err = logrecTable.Get(rec.ID.Bytes())
+	if rec.err != nil {
 		return
 	}
 
@@ -53,5 +55,6 @@ func (rec *logrec) FetchLog(
 	offset += common.AddressLength
 	r.Data = buf[offset:]
 
+	rec.result = r
 	return
 }

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -57,14 +57,13 @@ func (tt *Index) walk(
 				return
 			}
 		}
+
+		err = it.Error()
 		it.Release()
-		// TODO: why the panic ?
-		/*
-			err = it.Error()
-			if err != nil {
-				return
-			}
-		*/
+		if err != nil {
+			return
+		}
+
 	}
 
 	return

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -1,17 +1,22 @@
 package topicsdb
 
 import (
+	"context"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func (tt *Index) searchLazy(pattern [][]common.Hash, blockStart []byte, onMatched func(*logrec) (bool, error)) (err error) {
-	_, err = tt.walk(nil, blockStart, pattern, 0, onMatched)
+func (tt *Index) searchLazy(ctx context.Context, pattern [][]common.Hash, blockStart []byte, onMatched func(*logrec) (bool, error)) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err = tt.walk(ctx, nil, blockStart, pattern, 0, onMatched)
 	return
 }
 
 // walk for topics recursive.
 func (tt *Index) walk(
-	rec *logrec, blockStart []byte, pattern [][]common.Hash, pos uint8, onMatched func(*logrec) (bool, error),
+	ctx context.Context, rec *logrec, blockStart []byte, pattern [][]common.Hash, pos uint8, onMatched func(*logrec) (bool, error),
 ) (
 	gonext bool, err error,
 ) {
@@ -51,7 +56,7 @@ func (tt *Index) walk(
 			id := extractLogrecID(it.Key())
 			topicCount := bytesToPos(it.Value())
 			newRec := newLogrec(id, topicCount)
-			gonext, err = tt.walk(newRec, nil, pattern, pos+1, onMatched)
+			gonext, err = tt.walk(ctx, newRec, nil, pattern, pos+1, onMatched)
 			if err != nil || !gonext {
 				it.Release()
 				return

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -53,6 +53,12 @@ func (tt *Index) walk(
 
 		it := tt.table.Topic.NewIterator(prefix[:prefLen], blockStart)
 		for it.Next() {
+			err = ctx.Err()
+			if err != nil {
+				it.Release()
+				return
+			}
+
 			id := extractLogrecID(it.Key())
 			topicCount := bytesToPos(it.Value())
 			newRec := newLogrec(id, topicCount)

--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -58,6 +58,13 @@ func (tt *Index) walk(
 			}
 		}
 		it.Release()
+		// TODO: why the panic ?
+		/*
+			err = it.Error()
+			if err != nil {
+				return
+			}
+		*/
 	}
 
 	return

--- a/topicsdb/search_test.go
+++ b/topicsdb/search_test.go
@@ -4,20 +4,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkSearch(b *testing.B) {
-	topics, recs, topics4rec := genTestData()
+	topics, recs, topics4rec := genTestData(1000)
 
 	mem := memorydb.New()
 	mem.SetDelay(1 * time.Millisecond)
-	db := New(mem)
+	index := New(mem)
 
 	for _, rec := range recs {
-		err := db.Push(rec)
+		err := index.Push(rec)
 		require.NoError(b, err)
 	}
 
@@ -34,13 +36,18 @@ func BenchmarkSearch(b *testing.B) {
 		query = append(query, qq)
 	}
 
-	b.Run("Lazy", func(b *testing.B) {
-		b.ResetTimer()
+	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
+		"serial":   index.FindInBlocks,
+		"parallel": index.FindInBlocksParallel,
+	} {
+		b.Run(dsc, func(b *testing.B) {
+			b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
-			qq := query[i%len(query)]
-			_, err := db.Find(qq)
-			require.NoError(b, err)
-		}
-	})
+			for i := 0; i < b.N; i++ {
+				qq := query[i%len(query)]
+				_, err := method(0, 0xffffffff, qq)
+				require.NoError(b, err)
+			}
+		})
+	}
 }

--- a/topicsdb/search_test.go
+++ b/topicsdb/search_test.go
@@ -1,6 +1,7 @@
 package topicsdb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func BenchmarkSearch(b *testing.B) {
 		query = append(query, qq)
 	}
 
-	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
+	for dsc, method := range map[string]func(context.Context, idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
 		"sync":  index.FindInBlocks,
 		"async": index.FindInBlocksAsync,
 	} {
@@ -45,7 +46,7 @@ func BenchmarkSearch(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				qq := query[i%len(query)]
-				_, err := method(0, 0xffffffff, qq)
+				_, err := method(nil, 0, 0xffffffff, qq)
 				require.NoError(b, err)
 			}
 		})

--- a/topicsdb/search_test.go
+++ b/topicsdb/search_test.go
@@ -37,8 +37,8 @@ func BenchmarkSearch(b *testing.B) {
 	}
 
 	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
-		"serial":   index.FindInBlocks,
-		"parallel": index.FindInBlocksParallel,
+		"sync":  index.FindInBlocksSync,
+		"async": index.FindInBlocks,
 	} {
 		b.Run(dsc, func(b *testing.B) {
 			b.ResetTimer()

--- a/topicsdb/search_test.go
+++ b/topicsdb/search_test.go
@@ -37,8 +37,8 @@ func BenchmarkSearch(b *testing.B) {
 	}
 
 	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
-		"sync":  index.FindInBlocksSync,
-		"async": index.FindInBlocks,
+		"sync":  index.FindInBlocks,
+		"async": index.FindInBlocksAsync,
 	} {
 		b.Run(dsc, func(b *testing.B) {
 			b.ResetTimer()

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -77,6 +77,7 @@ func (tt *Index) FindInBlocksParallel(from, to idx.Block, pattern [][]common.Has
 			if rec.err != nil {
 				err = rec.err
 				failed = true
+				continue
 			}
 			logs = append(logs, rec.result)
 		}
@@ -84,7 +85,6 @@ func (tt *Index) FindInBlocksParallel(from, to idx.Block, pattern [][]common.Has
 
 	onMatched := func(rec *logrec) (gonext bool, err error) {
 		if rec.ID.BlockNumber() > uint64(to) {
-			gonext = false
 			return
 		}
 
@@ -135,7 +135,6 @@ func (tt *Index) ForEachInBlocks(from, to idx.Block, pattern [][]common.Hash, on
 
 	onMatched := func(rec *logrec) (gonext bool, err error) {
 		if rec.ID.BlockNumber() > uint64(to) {
-			gonext = false
 			return
 		}
 

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -40,22 +40,22 @@ func New(db kvdb.Store) *Index {
 	return tt
 }
 
-// ForEach matches log records by topics. 1st topics element is an address.
-func (tt *Index) ForEach(topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
-	if err := checkTopics(topics); err != nil {
+// ForEach matches log records by pattern. 1st pattern element is an address.
+func (tt *Index) ForEach(pattern [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
+	if err := checkPattern(pattern); err != nil {
 		return err
 	}
 
-	return tt.fetchLazy(topics, nil, onLog)
+	return tt.fetchLazy(pattern, nil, onLog)
 }
 
-// ForEachInBlocks matches log records of block range by topics. 1st topics element is an address.
-func (tt *Index) ForEachInBlocks(from, to idx.Block, topics [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
+// ForEachInBlocks matches log records of block range by pattern. 1st pattern element is an address.
+func (tt *Index) ForEachInBlocks(from, to idx.Block, pattern [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
 	if from > to {
 		return nil
 	}
 
-	if err := checkTopics(topics); err != nil {
+	if err := checkPattern(pattern); err != nil {
 		return err
 	}
 
@@ -66,16 +66,16 @@ func (tt *Index) ForEachInBlocks(from, to idx.Block, topics [][]common.Hash, onL
 		return onLog(l)
 	}
 
-	return tt.fetchLazy(topics, uintToBytes(uint64(from)), moreAccurate)
+	return tt.fetchLazy(pattern, uintToBytes(uint64(from)), moreAccurate)
 }
 
-func checkTopics(topics [][]common.Hash) error {
-	if len(topics) > MaxTopicsCount {
+func checkPattern(pattern [][]common.Hash) error {
+	if len(pattern) > MaxTopicsCount {
 		return ErrTooManyTopics
 	}
 
 	ok := false
-	for _, variants := range topics {
+	for _, variants := range pattern {
 		if len(variants) > MaxTopicsCount {
 			return ErrTooManyTopics
 		}

--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -40,6 +40,18 @@ func New(db kvdb.Store) *Index {
 	return tt
 }
 
+// FindInBlocks returns all log records of block range by pattern. 1st pattern element is an address.
+func (tt *Index) FindInBlocks(from, to idx.Block, pattern [][]common.Hash) (logs []*types.Log, err error) {
+	err = tt.ForEachInBlocks(
+		from, to, pattern,
+		func(l *types.Log) bool {
+			logs = append(logs, l)
+			return true
+		})
+
+	return
+}
+
 // ForEach matches log records by pattern. 1st pattern element is an address.
 func (tt *Index) ForEach(pattern [][]common.Hash, onLog func(*types.Log) (gonext bool)) error {
 	if err := checkPattern(pattern); err != nil {

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,17 +16,6 @@ import (
 // Find wraps ForEach() for tests.
 func (tt *Index) Find(topics [][]common.Hash) (all []*types.Log, err error) {
 	err = tt.ForEach(topics, func(item *types.Log) (next bool) {
-		all = append(all, item)
-		next = true
-		return
-	})
-
-	return
-}
-
-// FindInBlocks wraps ForEachInBlocks() for tests.
-func (tt *Index) FindInBlocks(from, to idx.Block, topics [][]common.Hash) (all []*types.Log, err error) {
-	err = tt.ForEachInBlocks(from, to, topics, func(item *types.Log) (next bool) {
 		all = append(all, item)
 		next = true
 		return

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/Fantom-foundation/go-opera/logger"
 )
 
+// FindInBlocksSync returns all log records of block range by pattern. 1st pattern element is an address.
+// The same as FindInBlocks but fetches log's body sync.
+func (tt *Index) FindInBlocksSync(from, to idx.Block, pattern [][]common.Hash) (logs []*types.Log, err error) {
+	err = tt.ForEachInBlocks(
+		from, to, pattern,
+		func(l *types.Log) bool {
+			logs = append(logs, l)
+			return true
+		})
+
+	return
+}
+
 func TestIndexSearchMultyVariants(t *testing.T) {
 	logger.SetTestMode(t)
 	var (
@@ -68,8 +81,8 @@ func TestIndexSearchMultyVariants(t *testing.T) {
 	}
 
 	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
-		"serial":   index.FindInBlocks,
-		"parallel": index.FindInBlocksParallel,
+		"sync":  index.FindInBlocksSync,
+		"async": index.FindInBlocks,
 	} {
 		t.Run(dsc, func(t *testing.T) {
 
@@ -129,8 +142,8 @@ func TestIndexSearchSingleVariant(t *testing.T) {
 	}
 
 	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
-		"serial":   index.FindInBlocks,
-		"parallel": index.FindInBlocksParallel,
+		"sync":  index.FindInBlocksSync,
+		"async": index.FindInBlocks,
 	} {
 		t.Run(dsc, func(t *testing.T) {
 			require := require.New(t)
@@ -204,8 +217,8 @@ func TestIndexSearchSimple(t *testing.T) {
 	)
 
 	for dsc, method := range map[string]func(idx.Block, idx.Block, [][]common.Hash) ([]*types.Log, error){
-		"serial":   index.FindInBlocks,
-		"parallel": index.FindInBlocksParallel,
+		"sync":  index.FindInBlocksSync,
+		"async": index.FindInBlocks,
 	} {
 		t.Run(dsc, func(t *testing.T) {
 			require := require.New(t)

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -103,9 +103,22 @@ func TestIndexSearchMultyVariants(t *testing.T) {
 		check(require, got)
 	})
 
-	t.Run("With by blocks", func(t *testing.T) {
+	t.Run("With block range", func(t *testing.T) {
 		require := require.New(t)
 		got, err := index.FindInBlocks(2, 998, [][]common.Hash{
+			{addr1.Hash(), addr2.Hash(), addr3.Hash(), addr4.Hash()},
+			{hash1, hash2, hash3, hash4},
+			{},
+			{hash1, hash2, hash3, hash4},
+		})
+		require.NoError(err)
+		require.Equal(2, len(got))
+		check(require, got)
+	})
+
+	t.Run("With block range parallel", func(t *testing.T) {
+		require := require.New(t)
+		got, err := index.FindInBlocksParallel(2, 998, [][]common.Hash{
 			{addr1.Hash(), addr2.Hash(), addr3.Hash(), addr4.Hash()},
 			{hash1, hash2, hash3, hash4},
 			{},


### PR DESCRIPTION
Changes:
  1. `gossip/filters.Filter` does not double `topicsdb.Index`'s filtration from now;
  2. `topicsdb/Index.FindInBlocks()` wraps ForEachInBlocks iterator to return all the logs;
  3.  `topicsdb/Index.FindInBlocks()` fetches log's bodies async;