### PR TITLE
Optimize filling event with transactions

### DIFF
--- a/gossip/emitter/piecefuncs.go
+++ b/gossip/emitter/piecefuncs.go
@@ -26,8 +26,12 @@ var (
 			Y: 10.0 * piecefunc.DecimalUnit,
 		},
 		{ // validators >0.8 emit confirming events very rarely
+			X: 0.81 * piecefunc.DecimalUnit,
+			Y: 50.0 * piecefunc.DecimalUnit,
+		},
+		{ // validators >0.8 emit confirming events very rarely
 			X: 1.0 * piecefunc.DecimalUnit,
-			Y: 1000.0 * piecefunc.DecimalUnit,
+			Y: 60.0 * piecefunc.DecimalUnit,
 		},
 	}
 	// eventMetricF is a piecewise function for validator's event metric diff depending on a number of newly observed events


### PR DESCRIPTION
- emitter doesn't loop over all the transactions if doesn't have enough gas to originate an empty transaction
- stake-based emission interval adjustment is capped by 60x
- fix output of maxGasPowerToUse in emitter