### PR TITLE
OperaEVMProcessor.Execute() fix

### DIFF
--- a/demo/start.sh
+++ b/demo/start.sh
@@ -26,7 +26,7 @@ do
 	--nat extip:127.0.0.1 \
 	--http --http.addr="127.0.0.1" --http.port=${RPCP} --http.corsdomain="*" --http.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
 	--ws --ws.addr="127.0.0.1" --ws.port=${WSP} --ws.origins="*" --ws.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
-	--nousb --verbosity=3 --tracing &> opera$i.log)&
+	--nousb --verbosity=3 --tracing &>> opera$i.log)&
 
     echo -e "\tnode$i ok"
 done
@@ -36,7 +36,7 @@ attach_and_exec() {
     local CMD=$2
     local RPCP=$(($RPCP_BASE+$i))
 
-    for attempt in $(seq 20)
+    for attempt in $(seq 40)
     do
         if (( attempt > 5 ));
         then 
@@ -57,6 +57,7 @@ attach_and_exec() {
     echo "failed RPC connection to ${NAME}" >&2
     return 1
 }
+
 
 echo -e "\nConnect nodes to ring:\n"
 for ((i=0;i<$N;i+=1))

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -84,8 +84,10 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, internal bool) types
 	}
 
 	offset := uint32(len(p.incomingTxs))
-	for i, n := range skipped {
-		skipped[i] = n + offset
+	if offset > 0 {
+		for i, n := range skipped {
+			skipped[i] = n + offset
+		}
 	}
 
 	p.gasUsed += gasUsed

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc"
+	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/utils"
 )
@@ -101,7 +102,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, internal bool) types
 func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts) {
 	evmBlock = p.evmBlockWith(
 		// Filter skipped transactions. Receipts are filtered already
-		filterSkippedTxs(p.incomingTxs, p.skippedTxs),
+		inter.FilterSkippedTxs(p.incomingTxs, p.skippedTxs),
 	)
 
 	// Get state root
@@ -112,22 +113,4 @@ func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs [
 	evmBlock.Root = newStateHash
 
 	return evmBlock, p.skippedTxs, p.receipts
-}
-
-func filterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {
-	if len(skippedTxs) == 0 {
-		// short circuit if nothing to skip
-		return txs
-	}
-	skipCount := 0
-	filteredTxs := make(types.Transactions, 0, len(txs))
-	for i, tx := range txs {
-		if skipCount < len(skippedTxs) && skippedTxs[skipCount] == uint32(i) {
-			skipCount++
-		} else {
-			filteredTxs = append(filteredTxs, tx)
-		}
-	}
-
-	return filteredTxs
 }

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -72,7 +72,6 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 }
 
 func (p *OperaEVMProcessor) Execute(txs types.Transactions, internal bool) types.Receipts {
-
 	evmProcessor := evmcore.NewStateProcessor(p.net.EvmChainConfig(), p.reader)
 
 	// Process txs
@@ -82,6 +81,11 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, internal bool) types
 	})
 	if err != nil {
 		log.Crit("EVM internal error", "err", err)
+	}
+
+	offset := uint32(len(p.incomingTxs))
+	for i, n := range skipped {
+		skipped[i] = n + offset
 	}
 
 	p.gasUsed += gasUsed

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -194,7 +194,6 @@ func consensusCallbackBeginBlockFn(
 					txs := make(types.Transactions, 0, blockEvents.Len()*10)
 					for _, e := range blockEvents {
 						txs = append(txs, e.Txs()...)
-						blockEvents = append(blockEvents, e)
 					}
 
 					externalReceipts := evmProcessor.Execute(txs, false)

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -55,19 +55,11 @@ func (r *EvmStateReader) CurrentHeader() *evmcore.EvmHeader {
 }
 
 func (r *EvmStateReader) GetHeader(h common.Hash, n uint64) *evmcore.EvmHeader {
-	return r.GetDagHeader(hash.Event(h), idx.Block(n))
+	return r.getBlock(hash.Event(h), idx.Block(n), false).Header()
 }
 
 func (r *EvmStateReader) GetBlock(h common.Hash, n uint64) *evmcore.EvmBlock {
-	return r.GetDagBlock(hash.Event(h), idx.Block(n))
-}
-
-func (r *EvmStateReader) GetDagHeader(h hash.Event, n idx.Block) *evmcore.EvmHeader {
-	return r.getBlock(h, n, false).Header()
-}
-
-func (r *EvmStateReader) GetDagBlock(h hash.Event, n idx.Block) *evmcore.EvmBlock {
-	return r.getBlock(h, n, true)
+	return r.getBlock(hash.Event(h), idx.Block(n), true)
 }
 
 func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmcore.EvmBlock {

--- a/gossip/evmstore/store_tx.go
+++ b/gossip/evmstore/store_tx.go
@@ -5,12 +5,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// SetTx stores transaction.
+// SetTx stores non-event transaction.
 func (s *Store) SetTx(txid common.Hash, tx *types.Transaction) {
 	s.rlp.Set(s.table.Txs, txid.Bytes(), tx)
 }
 
-// GetTx returns stored transaction.
+// GetTx returns stored non-event transaction.
 func (s *Store) GetTx(txid common.Hash) *types.Transaction {
 	tx, _ := s.rlp.Get(s.table.Txs, txid.Bytes(), &types.Transaction{}).(*types.Transaction)
 

--- a/inter/block.go
+++ b/inter/block.go
@@ -3,6 +3,7 @@ package inter
 import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type Block struct {
@@ -18,4 +19,22 @@ type Block struct {
 
 func (b *Block) EstimateSize() int {
 	return (len(b.Events)+len(b.InternalTxs)+len(b.Txs)+1+1)*32 + len(b.SkippedTxs)*4 + 8 + 8
+}
+
+func FilterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {
+	if len(skippedTxs) == 0 {
+		// short circuit if nothing to skip
+		return txs
+	}
+	skipCount := 0
+	filteredTxs := make(types.Transactions, 0, len(txs))
+	for i, tx := range txs {
+		if skipCount < len(skippedTxs) && skippedTxs[skipCount] == uint32(i) {
+			skipCount++
+		} else {
+			filteredTxs = append(filteredTxs, tx)
+		}
+	}
+
+	return filteredTxs
 }


### PR DESCRIPTION
Includes:
1. Some refactoring to make code cleaner;
2. Fix of `BlockCallbacks.EndBlock` makes blocks processing a bit faster;
3. Fix of `OperaEVMProcessor.Execute()` corrects indexes of skipped txs. The bug is that `OperaEVMProcessor.Finalize()` returns wrong `evmBlock.Transactions` list that leads to not the all txs' positions were written to db. 
