### PR TITLE
Event export API method

### DIFF
--- a/cmd/opera/launcher/export.go
+++ b/cmd/opera/launcher/export.go
@@ -51,7 +51,7 @@ func exportEvents(ctx *cli.Context) error {
 	defer gdb.Close()
 
 	backend := gossip.NewEthAPIBackendOverStore(gdb)
-	api := ethapi.NewPublicDAGChainAPI(backend)
+	api := ethapi.NewPrivateDAGChainAPI(backend)
 
 	return api.ExportEvents(context.Background(), from, to, fileName)
 }

--- a/cmd/opera/launcher/export.go
+++ b/cmd/opera/launcher/export.go
@@ -1,41 +1,44 @@
 package launcher
 
 import (
-	"compress/gzip"
+	"context"
 	"errors"
-	"io"
-	"os"
 	"path"
 	"strconv"
-	"strings"
-	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/status-im/keycard-go/hexutils"
+	"github.com/ethereum/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/Fantom-foundation/go-opera/ethapi"
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/go-opera/integration"
 )
 
-var (
-	eventsFileHeader  = hexutils.HexToBytes("7e995678")
-	eventsFileVersion = hexutils.HexToBytes("00010001")
-)
-
-// statsReportLimit is the time limit during import and export after which we
-// always print out progress. This avoids the user wondering what's going on.
-const statsReportLimit = 8 * time.Second
-
 func exportEvents(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")
+	}
+	fileName := ctx.Args().First()
+
+	from := rpc.BlockNumber(1)
+	if len(ctx.Args()) > 1 {
+		n, err := strconv.ParseUint(ctx.Args().Get(1), 10, 32)
+		if err != nil {
+			return err
+		}
+		from = rpc.BlockNumber(n)
+	}
+
+	to := rpc.BlockNumber(0)
+	if len(ctx.Args()) > 2 {
+		n, err := strconv.ParseUint(ctx.Args().Get(2), 10, 32)
+		if err != nil {
+			return err
+		}
+		to = rpc.BlockNumber(n)
 	}
 
 	cfg := makeAllConfigs(ctx)
@@ -47,50 +50,10 @@ func exportEvents(ctx *cli.Context) error {
 	}
 	defer gdb.Close()
 
-	fn := ctx.Args().First()
+	backend := gossip.NewEthAPIBackendOverStore(gdb)
+	api := ethapi.NewPublicDAGChainAPI(backend)
 
-	// Open the file handle and potentially wrap with a gzip stream
-	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer fh.Close()
-
-	var writer io.Writer = fh
-	if strings.HasSuffix(fn, ".gz") {
-		writer = gzip.NewWriter(writer)
-		defer writer.(*gzip.Writer).Close()
-	}
-
-	from := idx.Epoch(1)
-	if len(ctx.Args()) > 1 {
-		n, err := strconv.ParseUint(ctx.Args().Get(1), 10, 32)
-		if err != nil {
-			return err
-		}
-		from = idx.Epoch(n)
-	}
-	to := idx.Epoch(0)
-	if len(ctx.Args()) > 2 {
-		n, err := strconv.ParseUint(ctx.Args().Get(2), 10, 32)
-		if err != nil {
-			return err
-		}
-		to = idx.Epoch(n)
-	}
-
-	log.Info("Exporting events to file", "file", fn)
-	// Write header and version
-	_, err = writer.Write(append(eventsFileHeader, eventsFileVersion...))
-	if err != nil {
-		return err
-	}
-	err = exportTo(writer, gdb, from, to)
-	if err != nil {
-		utils.Fatalf("Export error: %v\n", err)
-	}
-
-	return nil
+	return api.ExportEvents(context.Background(), from, to, fileName)
 }
 
 func checkStateInitialized(rawProducer kvdb.IterableDBProducer) error {
@@ -121,33 +84,4 @@ func makeRawGossipStore(rawProducer kvdb.IterableDBProducer, cfg *config) (*goss
 	gdb := gossip.NewStore(dbs, cfg.OperaStore)
 	gdb.SetName("gossip-db")
 	return gdb, nil
-}
-
-// exportTo writer the active chain.
-func exportTo(w io.Writer, gdb *gossip.Store, from, to idx.Epoch) (err error) {
-	start, reported := time.Now(), time.Time{}
-
-	var (
-		counter int
-		last    hash.Event
-	)
-	gdb.ForEachEventRLP(from.Bytes(), func(id hash.Event, event rlp.RawValue) bool {
-		if to >= from && id.Epoch() > to {
-			return false
-		}
-		counter++
-		_, err = w.Write(event)
-		if err != nil {
-			return false
-		}
-		last = id
-		if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
-			log.Info("Exporting events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
-			reported = time.Now()
-		}
-		return true
-	})
-	log.Info("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
-
-	return
 }

--- a/cmd/opera/launcher/export.go
+++ b/cmd/opera/launcher/export.go
@@ -51,7 +51,7 @@ func exportEvents(ctx *cli.Context) error {
 	defer gdb.Close()
 
 	backend := gossip.NewEthAPIBackendOverStore(gdb)
-	api := ethapi.NewPrivateDAGChainAPI(backend)
+	api := ethapi.NewPrivateDebugAPI(backend)
 
 	return api.ExportEvents(context.Background(), from, to, fileName)
 }

--- a/cmd/opera/launcher/import.go
+++ b/cmd/opera/launcher/import.go
@@ -31,6 +31,15 @@ import (
 	"github.com/Fantom-foundation/go-opera/utils/ioread"
 )
 
+// statsReportLimit is the time limit during import and export after which we
+// always print out progress. This avoids the user wondering what's going on.
+const statsReportLimit = 8 * time.Second
+
+var ( // consts
+	eventsFileHeader  = hexutils.HexToBytes("7e995678")
+	eventsFileVersion = hexutils.HexToBytes("00010001")
+)
+
 func importEvm(ctx *cli.Context) error {
 	if len(ctx.Args()) < 1 {
 		utils.Fatalf("This command requires an argument.")

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -22,11 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -34,7 +32,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -1868,127 +1865,6 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 	}
 
 	return common.Hash{}, fmt.Errorf("transaction %#x not found", matchTx.Hash())
-}
-
-// PublicDebugAPI is the collection of Ethereum APIs exposed over the public
-// debugging endpoint.
-type PublicDebugAPI struct {
-	b Backend
-}
-
-// NewPublicDebugAPI creates a new API definition for the public debug methods
-// of the Ethereum service.
-func NewPublicDebugAPI(b Backend) *PublicDebugAPI {
-	return &PublicDebugAPI{b: b}
-}
-
-// GetBlockRlp retrieves the RLP encoded for of a single block.
-func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (string, error) {
-	block, _ := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
-	if block == nil {
-		return "", fmt.Errorf("block #%d not found", number)
-	}
-	encoded, err := rlp.EncodeToBytes(block)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", encoded), nil
-}
-
-// TestSignCliqueBlock fetches the given block number, and attempts to sign it as a clique header with the
-// given address, returning the address of the recovered signature
-//
-// This is a temporary method to debug the externalsigner integration,
-func (api *PublicDebugAPI) TestSignCliqueBlock(ctx context.Context, address common.Address, number uint64) (common.Address, error) {
-	return common.Address{}, errors.New("Clique isn't supported")
-}
-
-// PrintBlock retrieves a block and returns its pretty printed form.
-func (api *PublicDebugAPI) PrintBlock(ctx context.Context, number uint64) (string, error) {
-	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
-	if err != nil {
-		return "", err
-	}
-	if block == nil {
-		return "", fmt.Errorf("block #%d not found", number)
-	}
-	return spew.Sdump(block), nil
-}
-
-// SeedHash retrieves the seed hash of a block.
-func (api *PublicDebugAPI) SeedHash(ctx context.Context, number uint64) (string, error) {
-	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
-	if err != nil {
-		return "", err
-	}
-	if block == nil {
-		return "", fmt.Errorf("block #%d not found", number)
-	}
-	return fmt.Sprintf("0x%x", ethash.SeedHash(number)), nil
-}
-
-// BlocksTransactionTimes returns the map time => number of transactions
-// This data may be used to draw a histogram to calculate a peak TPS of a range of blocks
-func (api *PublicDebugAPI) BlocksTransactionTimes(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64) (map[hexutil.Uint64]hexutil.Uint, error) {
-
-	until, err := api.b.HeaderByNumber(ctx, untilBlock)
-	if err != nil {
-		return nil, err
-	}
-	untilN := until.Number.Uint64()
-	times := map[hexutil.Uint64]hexutil.Uint{}
-	for i := untilN; i >= 1 && i+uint64(maxBlocks) > untilN; i-- {
-		b, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(i))
-		if err != nil {
-			return nil, err
-		}
-		if b.Transactions.Len() == 0 {
-			continue
-		}
-		times[hexutil.Uint64(b.Time)] += hexutil.Uint(b.Transactions.Len())
-	}
-
-	return times, nil
-}
-
-// PrivateDebugAPI is the collection of Ethereum APIs exposed over the private
-// debugging endpoint.
-type PrivateDebugAPI struct {
-	b Backend
-}
-
-// NewPrivateDebugAPI creates a new API definition for the private debug methods
-// of the Ethereum service.
-func NewPrivateDebugAPI(b Backend) *PrivateDebugAPI {
-	return &PrivateDebugAPI{b: b}
-}
-
-// ChaindbProperty returns leveldb properties of the key-value database.
-func (api *PrivateDebugAPI) ChaindbProperty(property string) (string, error) {
-	if property == "" {
-		property = "leveldb.stats"
-	} else if !strings.HasPrefix(property, "leveldb.") {
-		property = "leveldb." + property
-	}
-	return api.b.ChainDb().Stat(property)
-}
-
-// ChaindbCompact flattens the entire key-value database into a single level,
-// removing all unused slots and merging all keys.
-func (api *PrivateDebugAPI) ChaindbCompact() error {
-	for b := byte(0); b < 255; b++ {
-		log.Info("Compacting chain database", "range", fmt.Sprintf("0x%0.2X-0x%0.2X", b, b+1))
-		if err := api.b.ChainDb().Compact([]byte{b}, []byte{b + 1}); err != nil {
-			log.Error("Database compaction failed", "err", err)
-			return err
-		}
-	}
-	return nil
-}
-
-// SetHead rewinds the head of the blockchain to a previous block.
-func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) error {
-	return errors.New("lachesis cannot rewind blocks due to the BFT algorithm")
 }
 
 // PublicNetAPI offers network related RPC methods

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -166,17 +166,16 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Namespace: "personal",
 			Version:   "1.0",
 			Service:   NewPrivateAccountAPI(apiBackend, nonceLock),
-			Public:    false,
 		}, {
 			Namespace: "sfc",
 			Version:   "1.0",
 			Service:   NewPublicSfcAPI(apiBackend),
-			Public:    false,
+			Public:    true,
 		}, {
 			Namespace: "abft",
 			Version:   "1.0",
 			Service:   NewPublicAbftAPI(apiBackend),
-			Public:    false,
+			Public:    true,
 		},
 	}
 

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -135,6 +135,10 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Service:   NewPublicDAGChainAPI(apiBackend),
 			Public:    true,
 		}, {
+			Namespace: "dag",
+			Version:   "1.0",
+			Service:   NewPrivateDAGChainAPI(apiBackend),
+		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -135,10 +135,6 @@ func GetAPIs(apiBackend Backend) []rpc.API {
 			Service:   NewPublicDAGChainAPI(apiBackend),
 			Public:    true,
 		}, {
-			Namespace: "dag",
-			Version:   "1.0",
-			Service:   NewPrivateDAGChainAPI(apiBackend),
-		}, {
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewPublicTransactionPoolAPI(apiBackend, nonceLock),

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
@@ -90,6 +91,7 @@ type Backend interface {
 	CurrentBlock() *evmcore.EvmBlock
 
 	// Lachesis DAG API
+	ForEachEventRLP(ctx context.Context, epoch rpc.BlockNumber, onEvent func(key hash.Event, event rlp.RawValue) bool) error
 	GetEventPayload(ctx context.Context, shortEventID string) (*inter.EventPayload, error)
 	GetEvent(ctx context.Context, shortEventID string) (*inter.Event, error)
 	GetHeads(ctx context.Context, epoch rpc.BlockNumber) (hash.Events, error)

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -81,6 +81,9 @@ const statsReportLimit = 8 * time.Second
 // ExportEvents writes RLP-encoded events into file.
 func (s *PublicDAGChainAPI) ExportEvents(ctx context.Context, epochFrom, epochTo rpc.BlockNumber, fileName string) error {
 	start, reported := time.Now(), time.Time{}
+	from := idx.Epoch(epochFrom)
+	to := idx.Epoch(epochTo)
+	log.Info("Exporting events to file", "file", fileName, "from", from, "to", to)
 
 	// Open the file handle and potentially wrap with a gzip stream
 	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
@@ -102,8 +105,6 @@ func (s *PublicDAGChainAPI) ExportEvents(ctx context.Context, epochFrom, epochTo
 	}
 
 	var (
-		from    = idx.Epoch(epochFrom)
-		to      = idx.Epoch(epochTo)
 		counter int
 		last    hash.Event
 	)
@@ -123,9 +124,14 @@ func (s *PublicDAGChainAPI) ExportEvents(ctx context.Context, epochFrom, epochTo
 		}
 		return true
 	})
-	log.Info("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
 
-	return err
+	if err != nil {
+		log.Error("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)), "err", err)
+		return err
+	}
+
+	log.Info("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+	return nil
 }
 
 // GetEpochStats returns epoch statistics.

--- a/ethapi/dag_api.go
+++ b/ethapi/dag_api.go
@@ -1,24 +1,14 @@
 package ethapi
 
 import (
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
-	"os"
-	"strings"
-	"time"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 // PublicDAGChainAPI provides an API to access the directed acyclic graph chain.
@@ -86,81 +76,4 @@ func (s *PublicBlockChainAPI) GetEpochStats(ctx context.Context, requestedEpoch 
 		"totalBaseRewardWeight": (*hexutil.Big)(new(big.Int)),
 		"totalTxRewardWeight":   (*hexutil.Big)(new(big.Int)),
 	}, nil
-}
-
-// PrivateDAGChainAPI provides an API to access the directed acyclic graph chain.
-// It offers methods that operate on public data that is freely available to anyone,
-// but can be hard to execute.
-type PrivateDAGChainAPI struct {
-	b Backend
-}
-
-// NewPrivateDAGChainAPI creates a new DAG chain API.
-func NewPrivateDAGChainAPI(b Backend) *PrivateDAGChainAPI {
-	return &PrivateDAGChainAPI{b}
-}
-
-var ( // consts
-	eventsFileHeader  = hexutils.HexToBytes("7e995678")
-	eventsFileVersion = hexutils.HexToBytes("00010001")
-)
-
-// statsReportLimit is the time limit during import and export after which we
-// always print out progress. This avoids the user wondering what's going on.
-const statsReportLimit = 8 * time.Second
-
-// ExportEvents writes RLP-encoded events into file.
-func (s *PrivateDAGChainAPI) ExportEvents(ctx context.Context, epochFrom, epochTo rpc.BlockNumber, fileName string) error {
-	start, reported := time.Now(), time.Time{}
-	from := idx.Epoch(epochFrom)
-	to := idx.Epoch(epochTo)
-	log.Info("Exporting events to file", "file", fileName, "from", from, "to", to)
-
-	// Open the file handle and potentially wrap with a gzip stream
-	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	var w io.Writer = f
-	if strings.HasSuffix(fileName, ".gz") {
-		w = gzip.NewWriter(w)
-		defer w.(*gzip.Writer).Close()
-	}
-
-	// Write header and version
-	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))
-	if err != nil {
-		return err
-	}
-
-	var (
-		counter int
-		last    hash.Event
-	)
-	err = s.b.ForEachEventRLP(ctx, epochFrom, func(id hash.Event, event rlp.RawValue) bool {
-		if to >= from && id.Epoch() > to {
-			return false
-		}
-		counter++
-		_, err = w.Write(event)
-		if err != nil {
-			return false
-		}
-		last = id
-		if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
-			log.Info("Exporting events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
-			reported = time.Now()
-		}
-		return true
-	})
-
-	if err != nil {
-		log.Error("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)), "err", err)
-		return err
-	}
-
-	log.Info("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
-	return nil
 }

--- a/ethapi/debug_api.go
+++ b/ethapi/debug_api.go
@@ -1,0 +1,137 @@
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// PublicDebugAPI is the collection of Ethereum APIs exposed over the public
+// debugging endpoint.
+type PublicDebugAPI struct {
+	b Backend
+}
+
+// NewPublicDebugAPI creates a new API definition for the public debug methods
+// of the Ethereum service.
+func NewPublicDebugAPI(b Backend) *PublicDebugAPI {
+	return &PublicDebugAPI{b: b}
+}
+
+// GetBlockRlp retrieves the RLP encoded for of a single block.
+func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (string, error) {
+	block, _ := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
+	if block == nil {
+		return "", fmt.Errorf("block #%d not found", number)
+	}
+	encoded, err := rlp.EncodeToBytes(block)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", encoded), nil
+}
+
+// TestSignCliqueBlock fetches the given block number, and attempts to sign it as a clique header with the
+// given address, returning the address of the recovered signature
+//
+// This is a temporary method to debug the externalsigner integration,
+func (api *PublicDebugAPI) TestSignCliqueBlock(ctx context.Context, address common.Address, number uint64) (common.Address, error) {
+	return common.Address{}, errors.New("Clique isn't supported")
+}
+
+// PrintBlock retrieves a block and returns its pretty printed form.
+func (api *PublicDebugAPI) PrintBlock(ctx context.Context, number uint64) (string, error) {
+	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
+	if err != nil {
+		return "", err
+	}
+	if block == nil {
+		return "", fmt.Errorf("block #%d not found", number)
+	}
+	return spew.Sdump(block), nil
+}
+
+// SeedHash retrieves the seed hash of a block.
+func (api *PublicDebugAPI) SeedHash(ctx context.Context, number uint64) (string, error) {
+	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))
+	if err != nil {
+		return "", err
+	}
+	if block == nil {
+		return "", fmt.Errorf("block #%d not found", number)
+	}
+	return fmt.Sprintf("0x%x", ethash.SeedHash(number)), nil
+}
+
+// BlocksTransactionTimes returns the map time => number of transactions
+// This data may be used to draw a histogram to calculate a peak TPS of a range of blocks
+func (api *PublicDebugAPI) BlocksTransactionTimes(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64) (map[hexutil.Uint64]hexutil.Uint, error) {
+
+	until, err := api.b.HeaderByNumber(ctx, untilBlock)
+	if err != nil {
+		return nil, err
+	}
+	untilN := until.Number.Uint64()
+	times := map[hexutil.Uint64]hexutil.Uint{}
+	for i := untilN; i >= 1 && i+uint64(maxBlocks) > untilN; i-- {
+		b, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(i))
+		if err != nil {
+			return nil, err
+		}
+		if b.Transactions.Len() == 0 {
+			continue
+		}
+		times[hexutil.Uint64(b.Time)] += hexutil.Uint(b.Transactions.Len())
+	}
+
+	return times, nil
+}
+
+// PrivateDebugAPI is the collection of Ethereum APIs exposed over the private
+// debugging endpoint.
+type PrivateDebugAPI struct {
+	b Backend
+}
+
+// NewPrivateDebugAPI creates a new API definition for the private debug methods
+// of the Ethereum service.
+func NewPrivateDebugAPI(b Backend) *PrivateDebugAPI {
+	return &PrivateDebugAPI{b: b}
+}
+
+// ChaindbProperty returns leveldb properties of the key-value database.
+func (api *PrivateDebugAPI) ChaindbProperty(property string) (string, error) {
+	if property == "" {
+		property = "leveldb.stats"
+	} else if !strings.HasPrefix(property, "leveldb.") {
+		property = "leveldb." + property
+	}
+	return api.b.ChainDb().Stat(property)
+}
+
+// ChaindbCompact flattens the entire key-value database into a single level,
+// removing all unused slots and merging all keys.
+func (api *PrivateDebugAPI) ChaindbCompact() error {
+	for b := byte(0); b < 255; b++ {
+		log.Info("Compacting chain database", "range", fmt.Sprintf("0x%0.2X-0x%0.2X", b, b+1))
+		if err := api.b.ChainDb().Compact([]byte{b}, []byte{b + 1}); err != nil {
+			log.Error("Database compaction failed", "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// SetHead rewinds the head of the blockchain to a previous block.
+func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) error {
+	return errors.New("lachesis cannot rewind blocks due to the BFT algorithm")
+}

--- a/ethapi/debug_api.go
+++ b/ethapi/debug_api.go
@@ -1,11 +1,17 @@
 package ethapi
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
+	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -13,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/keycard-go/hexutils"
 )
 
 // PublicDebugAPI is the collection of Ethereum APIs exposed over the public
@@ -134,4 +141,69 @@ func (api *PrivateDebugAPI) ChaindbCompact() error {
 // SetHead rewinds the head of the blockchain to a previous block.
 func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) error {
 	return errors.New("lachesis cannot rewind blocks due to the BFT algorithm")
+}
+
+var ( // consts
+	eventsFileHeader  = hexutils.HexToBytes("7e995678")
+	eventsFileVersion = hexutils.HexToBytes("00010001")
+)
+
+// statsReportLimit is the time limit during import and export after which we
+// always print out progress. This avoids the user wondering what's going on.
+const statsReportLimit = 8 * time.Second
+
+// ExportEvents writes RLP-encoded events into file.
+func (s *PrivateDebugAPI) ExportEvents(ctx context.Context, epochFrom, epochTo rpc.BlockNumber, fileName string) error {
+	start, reported := time.Now(), time.Time{}
+	from := idx.Epoch(epochFrom)
+	to := idx.Epoch(epochTo)
+	log.Info("Exporting events to file", "file", fileName, "from", from, "to", to)
+
+	// Open the file handle and potentially wrap with a gzip stream
+	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var w io.Writer = f
+	if strings.HasSuffix(fileName, ".gz") {
+		w = gzip.NewWriter(w)
+		defer w.(*gzip.Writer).Close()
+	}
+
+	// Write header and version
+	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))
+	if err != nil {
+		return err
+	}
+
+	var (
+		counter int
+		last    hash.Event
+	)
+	err = s.b.ForEachEventRLP(ctx, epochFrom, func(id hash.Event, event rlp.RawValue) bool {
+		if to >= from && id.Epoch() > to {
+			return false
+		}
+		counter++
+		_, err = w.Write(event)
+		if err != nil {
+			return false
+		}
+		last = id
+		if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+			log.Info("Exporting events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+			reported = time.Now()
+		}
+		return true
+	})
+
+	if err != nil {
+		log.Error("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)), "err", err)
+		return err
+	}
+
+	log.Info("Exported events", "last", last.String(), "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+	return nil
 }

--- a/ethapi/debug_api.go
+++ b/ethapi/debug_api.go
@@ -19,7 +19,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/status-im/keycard-go/hexutils"
+
+	"github.com/Fantom-foundation/go-opera/inter"
 )
 
 // PublicDebugAPI is the collection of Ethereum APIs exposed over the public
@@ -143,11 +144,6 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) error {
 	return errors.New("lachesis cannot rewind blocks due to the BFT algorithm")
 }
 
-var ( // consts
-	eventsFileHeader  = hexutils.HexToBytes("7e995678")
-	eventsFileVersion = hexutils.HexToBytes("00010001")
-)
-
 // statsReportLimit is the time limit during import and export after which we
 // always print out progress. This avoids the user wondering what's going on.
 const statsReportLimit = 8 * time.Second
@@ -172,8 +168,7 @@ func (s *PrivateDebugAPI) ExportEvents(ctx context.Context, epochFrom, epochTo r
 		defer w.(*gzip.Writer).Close()
 	}
 
-	// Write header and version
-	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))
+	w, err = inter.EventsRLPWriter(w)
 	if err != nil {
 		return err
 	}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -44,6 +44,15 @@ type EthAPIBackend struct {
 	gpo           *gasprice.Oracle
 }
 
+// NewEthAPIBackendOverStore initialises with only store.
+func NewEthAPIBackendOverStore(s *Store) *EthAPIBackend {
+	return &EthAPIBackend{
+		svc: &Service{
+			store: s,
+		},
+	}
+}
+
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.svc.store.GetRules().EvmChainConfig()


### PR DESCRIPTION
API method 'debug_exportEvents' doubles command `./opera export ...` functionality, but allows to do it without node stopping.
Helps to make more simple and reliable snapshots server, for example.
