### PR TITLE
Test coverage of utils/cser

### DIFF
--- a/inter/event_serializer.go
+++ b/inter/event_serializer.go
@@ -137,7 +137,7 @@ func (e *EventPayload) MarshalCSER(w *cser.Writer) error {
 	w.FixedBytes(e.sig.Bytes())
 	if !e.NoTxs() {
 		// txs size
-		w.U64fromZero(uint64(e.txs.Len()))
+		w.U56(uint64(e.txs.Len()))
 		// txs
 		for _, tx := range e.txs {
 			err := TransactionMarshalCSER(w, tx)
@@ -158,7 +158,7 @@ func (e *MutableEventPayload) UnmarshalCSER(r *cser.Reader) error {
 	txs := types.Transactions{}
 	if !e.NoTxs() {
 		// txs size
-		size := r.U64fromZero()
+		size := r.U56()
 		for i := uint64(0); i < size; i++ {
 			tx, err := TransactionUnmarshalCSER(r)
 			if err != nil {

--- a/inter/event_serializer.go
+++ b/inter/event_serializer.go
@@ -178,7 +178,7 @@ func (e *EventPayload) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaller interface.
 func (e *MutableEventPayload) UnmarshalBinary(raw []byte) (err error) {
-	return cser.UnmmrshalBinaryAdapter(raw, e.UnmarshalCSER)
+	return cser.UnmarshalBinaryAdapter(raw, e.UnmarshalCSER)
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaller interface.

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -53,69 +53,44 @@ func TestEventPayloadSerialization(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		assertar := assert.New(t)
+		require := require.New(t)
 
 		for name, header0 := range ee {
 			buf, err := rlp.EncodeToBytes(&header0)
-			if !assertar.NoError(err) {
-				return
-			}
+			require.NoError(err)
 
 			var header1 EventPayload
 			err = rlp.DecodeBytes(buf, &header1)
-			if !assertar.NoError(err, name) {
-				return
-			}
+			require.NoError(err, name)
 
-			if !assert.EqualValues(t, header0.extEventData, header1.extEventData, name) {
-				return
-			}
-			if !assert.EqualValues(t, header0.sigData, header1.sigData, name) {
-				return
-			}
+			require.EqualValues(header0.extEventData, header1.extEventData, name)
+			require.EqualValues(header0.sigData, header1.sigData, name)
 			for i := range header0.payloadData.txs {
-				if !assert.EqualValues(t, header0.payloadData.txs[i].Hash(), header1.payloadData.txs[i].Hash(), name) {
-					return
-				}
+				require.EqualValues(header0.payloadData.txs[i].Hash(), header1.payloadData.txs[i].Hash(), name)
 			}
-			if !assert.EqualValues(t, header0.baseEvent, header1.baseEvent, name) {
-				return
-			}
-			if !assert.EqualValues(t, header0.ID(), header1.ID(), name) {
-				return
-			}
-			if !assert.EqualValues(t, header0.HashToSign(), header1.HashToSign(), name) {
-				return
-			}
-			if !assert.EqualValues(t, header0.Size(), header1.Size(), name) {
-				return
-			}
+			require.EqualValues(header0.baseEvent, header1.baseEvent, name)
+			require.EqualValues(header0.ID(), header1.ID(), name)
+			require.EqualValues(header0.HashToSign(), header1.HashToSign(), name)
+			require.EqualValues(header0.Size(), header1.Size(), name)
 		}
 	})
 
 	t.Run("err", func(t *testing.T) {
-		assertar := assert.New(t)
+		require := require.New(t)
 
 		for name, header0 := range ee {
 			bin, err := header0.MarshalBinary()
-			if !assertar.NoError(err, name) {
-				return
-			}
+			require.NoError(err, name)
 
 			n := rand.Intn(len(bin) - len(header0.Extra()) - 1)
 			bin = bin[0:n]
 
 			buf, err := rlp.EncodeToBytes(bin)
-			if !assertar.NoError(err, name) {
-				return
-			}
+			require.NoError(err, name)
 
 			var header1 Event
 			err = rlp.DecodeBytes(buf, &header1)
-			if !assertar.Error(err, name) {
-				return
-			}
-			//t.Log(err)
+			require.Error(err, name)
 		}
 	})
 }

--- a/utils/cser/binary.go
+++ b/utils/cser/binary.go
@@ -5,19 +5,14 @@ import (
 	"github.com/Fantom-foundation/go-opera/utils/fast"
 )
 
-func MarshalBinaryAdapter(marshalCser func(writer *Writer) error) ([]byte, error) {
-	bodyBits := &bits.Array{Bytes: make([]byte, 0, 32)}
-	bodyBytes := fast.NewWriter(make([]byte, 0, 200))
-	bodyWriter := &Writer{
-		BitsW:  bits.NewWriter(bodyBits),
-		BytesW: bodyBytes,
-	}
-	err := marshalCser(bodyWriter)
+func MarshalBinaryAdapter(marshalCser func(*Writer) error) ([]byte, error) {
+	w := NewWriter()
+	err := marshalCser(w)
 	if err != nil {
 		return nil, err
 	}
 
-	return binaryFromCSER(bodyBits, bodyBytes.Bytes())
+	return binaryFromCSER(w.BitsW.Array, w.BytesW.Bytes())
 }
 
 // binaryFromCSER packs body bytes and bits into raw
@@ -56,14 +51,14 @@ func UnmarshalBinaryAdapter(raw []byte, unmarshalCser func(reader *Reader) error
 		}
 	}()
 
-	bodyBits, bodyBytes, err := binaryToCSER(raw)
+	bbits, bbytes, err := binaryToCSER(raw)
 	if err != nil {
 		return err
 	}
 
 	bodyReader := &Reader{
-		BitsR:  bits.NewReader(bodyBits),
-		BytesR: fast.NewReader(bodyBytes),
+		BitsR:  bits.NewReader(bbits),
+		BytesR: fast.NewReader(bbytes),
 	}
 	err = unmarshalCser(bodyReader)
 	if err != nil {

--- a/utils/cser/binary.go
+++ b/utils/cser/binary.go
@@ -26,8 +26,7 @@ func MarshalBinaryAdapter(marshalCser func(writer *Writer) error) ([]byte, error
 	return bodyBytes.Bytes(), nil
 }
 
-// UnmarshalBinary implements encoding.BinaryUnmarshaler interface.
-func BinaryToCSER(raw []byte) (bodyBits *bits.Array, bodyBytes []byte, err error) {
+func binaryToCSER(raw []byte) (bodyBits *bits.Array, bodyBytes []byte, err error) {
 	// read bitsArray size
 	bitsSizeBuf := reversed(tail(raw, 9))
 	bitsSizeReader := fast.NewReader(bitsSizeBuf)
@@ -43,13 +42,13 @@ func BinaryToCSER(raw []byte) (bodyBits *bits.Array, bodyBytes []byte, err error
 	return bodyBits, bodyBytes, nil
 }
 
-func UnmmrshalBinaryAdapter(raw []byte, unmarshalCser func(reader *Reader) error) (err error) {
+func UnmarshalBinaryAdapter(raw []byte, unmarshalCser func(reader *Reader) error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = ErrMalformedEncoding
 		}
 	}()
-	bodyBits, bodyBytes_, err := BinaryToCSER(raw)
+	bodyBits, bodyBytes_, err := binaryToCSER(raw)
 	if err != nil {
 		return err
 	}

--- a/utils/cser/binary_test.go
+++ b/utils/cser/binary_test.go
@@ -1,38 +1,155 @@
 package cser
 
 import (
+	"errors"
 	"math"
 	"math/big"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Fantom-foundation/go-opera/utils/fast"
 )
 
 func TestEmpty(t *testing.T) {
 	var (
-		raw []byte
+		buf []byte
 		err error
 	)
 
 	t.Run("Write", func(t *testing.T) {
-		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+		buf, err = MarshalBinaryAdapter(func(w *Writer) error {
 			return nil
 		})
 		require.NoError(t, err)
 	})
 
 	t.Run("Read", func(t *testing.T) {
-		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+		err = UnmarshalBinaryAdapter(buf, func(r *Reader) error {
 			return nil
 		})
 		require.NoError(t, err)
 	})
 }
 
+func TestErr(t *testing.T) {
+	var (
+		buf []byte
+	)
+
+	bufCopy := func() []byte {
+		bb := make([]byte, len(buf))
+		copy(bb, buf)
+		return bb
+	}
+
+	t.Run("Write", func(t *testing.T) {
+		require := require.New(t)
+
+		bb, err := MarshalBinaryAdapter(func(w *Writer) error {
+			w.U64(math.MaxUint64)
+			return nil
+		})
+		require.NoError(err)
+		buf = append(buf, bb...)
+
+		errExp := errors.New("custom")
+		bb, err = MarshalBinaryAdapter(func(w *Writer) error {
+			w.Bool(false)
+			return errExp
+		})
+		require.Equal(errExp, err)
+		buf = append(buf, bb...)
+	})
+
+	t.Run("Read nil", func(t *testing.T) {
+		require := require.New(t)
+		// nothing unmarshal
+		err := UnmarshalBinaryAdapter(nil, func(r *Reader) error {
+			return nil
+		})
+		require.Equal(ErrMalformedEncoding, err)
+	})
+
+	t.Run("Read err", func(t *testing.T) {
+		require := require.New(t)
+
+		errExp := errors.New("custom")
+		// unmarshal
+		err := UnmarshalBinaryAdapter(buf, func(r *Reader) error {
+			require.Equal(uint64(math.MaxUint64), r.U64())
+			return errExp
+		})
+		require.Equal(errExp, err)
+	})
+
+	t.Run("Read 0", func(t *testing.T) {
+		require := require.New(t)
+		// unpack
+		_, bbytes, err := binaryToCSER(bufCopy())
+		require.NoError(err)
+		// pack with wrong bits size
+		corrupted := fast.NewWriter(bbytes)
+		sizeWriter := fast.NewWriter(make([]byte, 0, 4))
+		writeUint64Compact(sizeWriter, uint64(len(bbytes)+1))
+		corrupted.Write(reversed(sizeWriter.Bytes()))
+		// corrupted unpack
+		_, _, err = binaryToCSER(corrupted.Bytes())
+		require.Equal(ErrMalformedEncoding, err)
+		// corrupted unmarshal
+		err = UnmarshalBinaryAdapter(corrupted.Bytes(), func(r *Reader) error {
+			require.Equal(uint64(math.MaxUint64), r.U64())
+			return nil
+		})
+		require.Equal(ErrMalformedEncoding, err)
+	})
+
+	repackWithDefect := func(
+		defect func(bbits, bbytes *[]byte) (expected error),
+	) func(t *testing.T) {
+		return func(t *testing.T) {
+			require := require.New(t)
+			// unpack
+			bbits, bbytes, err := binaryToCSER(bufCopy())
+			require.NoError(err)
+			// pack with defect
+			errExp := defect(&bbits.Bytes, &bbytes)
+			corrupted, err := binaryFromCSER(bbits, bbytes)
+			require.NoError(err)
+			// corrupted unmarshal
+			err = UnmarshalBinaryAdapter(corrupted, func(r *Reader) error {
+				_ = r.U64()
+				return nil
+			})
+			require.Equal(errExp, err)
+		}
+	}
+
+	t.Run("Read 1", repackWithDefect(func(bbits, bbytes *[]byte) (expected error) {
+		// no defect
+		return nil
+	}))
+
+	t.Run("Read 2", repackWithDefect(func(bbits, bbytes *[]byte) (expected error) {
+		*bbytes = append(*bbytes, 0xFF)
+		return ErrNonCanonicalEncoding
+	}))
+
+	t.Run("Read 3", repackWithDefect(func(bbits, bbytes *[]byte) (expected error) {
+		*bbits = append(*bbits, 0x0F)
+		return ErrNonCanonicalEncoding
+	}))
+
+	t.Run("Read 4", repackWithDefect(func(bbits, bbytes *[]byte) (expected error) {
+		*bbytes = (*bbytes)[:len(*bbytes)-1]
+		return ErrNonCanonicalEncoding
+	}))
+}
+
 func TestVals(t *testing.T) {
 	var (
-		raw []byte
+		buf []byte
 		err error
 	)
 	var (
@@ -52,7 +169,7 @@ func TestVals(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
 		require := require.New(t)
 
-		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+		buf, err = MarshalBinaryAdapter(func(w *Writer) error {
 			for _, v := range expBigInt {
 				w.BigInt(v)
 			}
@@ -94,7 +211,7 @@ func TestVals(t *testing.T) {
 	t.Run("Read", func(t *testing.T) {
 		require := require.New(t)
 
-		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+		err = UnmarshalBinaryAdapter(buf, func(r *Reader) error {
 			for i, exp := range expBigInt {
 				got := r.BigInt()
 				require.Equal(exp, got, i)
@@ -148,7 +265,7 @@ func TestVals(t *testing.T) {
 
 func TestBadVals(t *testing.T) {
 	var (
-		raw []byte
+		buf []byte
 		err error
 	)
 	var (
@@ -161,7 +278,7 @@ func TestBadVals(t *testing.T) {
 	t.Run("Write", func(t *testing.T) {
 		require := require.New(t)
 
-		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+		buf, err = MarshalBinaryAdapter(func(w *Writer) error {
 			for _, v := range expBigInt {
 				require.Panics(func() {
 					w.BigInt(v)
@@ -186,7 +303,7 @@ func TestBadVals(t *testing.T) {
 	t.Run("Read", func(t *testing.T) {
 		require := require.New(t)
 
-		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+		err = UnmarshalBinaryAdapter(buf, func(r *Reader) error {
 			for _, _ = range expBigInt {
 				// skip
 			}

--- a/utils/cser/binary_test.go
+++ b/utils/cser/binary_test.go
@@ -36,17 +36,17 @@ func TestVals(t *testing.T) {
 		err error
 	)
 	var (
-		expBigInt      = []*big.Int{big.NewInt(0), big.NewInt(0xFFFFF)}
-		expBool        = []bool{true, false}
-		expFixedBytes  = [][]byte{[]byte{}, randBytes(0xFF)}
-		expSliceBytes  = [][]byte{[]byte{}, randBytes(0xFF)}
-		expU8          = []uint8{0, 1, 0xFF}
-		expU16         = []uint16{0, 1, 0xFFFF}
-		expU32         = []uint32{0, 1, 0xFFFFFFFF}
-		expU64         = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
-		expVarUint     = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
-		expI64         = []int64{0, 1, math.MinInt64, math.MaxInt64}
-		expU64fromZero = []uint64{0, 1, 1<<(8*7) - 1}
+		expBigInt     = []*big.Int{big.NewInt(0), big.NewInt(0xFFFFF)}
+		expBool       = []bool{true, false}
+		expFixedBytes = [][]byte{[]byte{}, randBytes(0xFF)}
+		expSliceBytes = [][]byte{[]byte{}, randBytes(0xFF)}
+		expU8         = []uint8{0, 1, 0xFF}
+		expU16        = []uint16{0, 1, 0xFFFF}
+		expU32        = []uint32{0, 1, 0xFFFFFFFF}
+		expU64        = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
+		expVarUint    = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
+		expI64        = []int64{0, 1, math.MinInt64, math.MaxInt64}
+		expU56        = []uint64{0, 1, 1<<(8*7) - 1}
 	)
 
 	t.Run("Write", func(t *testing.T) {
@@ -83,8 +83,8 @@ func TestVals(t *testing.T) {
 			for _, v := range expI64 {
 				w.I64(v)
 			}
-			for _, v := range expU64fromZero {
-				w.U64fromZero(v)
+			for _, v := range expU56 {
+				w.U56(v)
 			}
 			return nil
 		})
@@ -136,8 +136,8 @@ func TestVals(t *testing.T) {
 				got := r.I64()
 				require.Equal(exp, got, i)
 			}
-			for i, exp := range expU64fromZero {
-				got := r.U64fromZero()
+			for i, exp := range expU56 {
+				got := r.U56()
 				require.Equal(exp, got, i)
 			}
 			return nil
@@ -152,10 +152,10 @@ func TestBadVals(t *testing.T) {
 		err error
 	)
 	var (
-		expBigInt      = []*big.Int{nil}
-		expFixedBytes  = [][]byte{nil}
-		expSliceBytes  = [][]byte{nil}
-		expU64fromZero = []uint64{1 << (8 * 7), math.MaxUint64}
+		expBigInt     = []*big.Int{nil}
+		expFixedBytes = [][]byte{nil}
+		expSliceBytes = [][]byte{nil}
+		expU56        = []uint64{1 << (8 * 7), math.MaxUint64}
 	)
 
 	t.Run("Write", func(t *testing.T) {
@@ -173,9 +173,9 @@ func TestBadVals(t *testing.T) {
 			for _, v := range expSliceBytes {
 				w.SliceBytes(v)
 			}
-			for _, v := range expU64fromZero {
+			for _, v := range expU56 {
 				require.Panics(func() {
-					w.U64fromZero(v)
+					w.U56(v)
 				})
 			}
 			return nil
@@ -201,7 +201,7 @@ func TestBadVals(t *testing.T) {
 				require.NotEqual(exp, got, i)
 				require.Equal(len(exp), len(got), i)
 			}
-			for _, _ = range expU64fromZero {
+			for _, _ = range expU56 {
 				// skip
 			}
 			return nil

--- a/utils/cser/binary_test.go
+++ b/utils/cser/binary_test.go
@@ -1,0 +1,220 @@
+package cser
+
+import (
+	"math"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmpty(t *testing.T) {
+	var (
+		raw []byte
+		err error
+	)
+
+	t.Run("Write", func(t *testing.T) {
+		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+			return nil
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestVals(t *testing.T) {
+	var (
+		raw []byte
+		err error
+	)
+	var (
+		expBigInt      = []*big.Int{big.NewInt(0), big.NewInt(0xFFFFF)}
+		expBool        = []bool{true, false}
+		expFixedBytes  = [][]byte{[]byte{}, randBytes(0xFF)}
+		expSliceBytes  = [][]byte{[]byte{}, randBytes(0xFF)}
+		expU8          = []uint8{0, 1, 0xFF}
+		expU16         = []uint16{0, 1, 0xFFFF}
+		expU32         = []uint32{0, 1, 0xFFFFFFFF}
+		expU64         = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
+		expVarUint     = []uint64{0, 1, 0xFFFFFFFFFFFFFFFF}
+		expI64         = []int64{0, 1, math.MinInt64, math.MaxInt64}
+		expU64fromZero = []uint64{0, 1, 1<<(8*7) - 1}
+	)
+
+	t.Run("Write", func(t *testing.T) {
+		require := require.New(t)
+
+		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+			for _, v := range expBigInt {
+				w.BigInt(v)
+			}
+			for _, v := range expBool {
+				w.Bool(v)
+			}
+			for _, v := range expFixedBytes {
+				w.FixedBytes(v)
+			}
+			for _, v := range expSliceBytes {
+				w.SliceBytes(v)
+			}
+			for _, v := range expU8 {
+				w.U8(v)
+			}
+			for _, v := range expU16 {
+				w.U16(v)
+			}
+			for _, v := range expU32 {
+				w.U32(v)
+			}
+			for _, v := range expU64 {
+				w.U64(v)
+			}
+			for _, v := range expVarUint {
+				w.VarUint(v)
+			}
+			for _, v := range expI64 {
+				w.I64(v)
+			}
+			for _, v := range expU64fromZero {
+				w.U64fromZero(v)
+			}
+			return nil
+		})
+		require.NoError(err)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		require := require.New(t)
+
+		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+			for i, exp := range expBigInt {
+				got := r.BigInt()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expBool {
+				got := r.Bool()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expFixedBytes {
+				got := make([]byte, len(exp))
+				r.FixedBytes(got)
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expSliceBytes {
+				got := r.SliceBytes()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expU8 {
+				got := r.U8()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expU16 {
+				got := r.U16()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expU32 {
+				got := r.U32()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expU64 {
+				got := r.U64()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expVarUint {
+				got := r.VarUint()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expI64 {
+				got := r.I64()
+				require.Equal(exp, got, i)
+			}
+			for i, exp := range expU64fromZero {
+				got := r.U64fromZero()
+				require.Equal(exp, got, i)
+			}
+			return nil
+		})
+		require.NoError(err)
+	})
+}
+
+func TestBadVals(t *testing.T) {
+	var (
+		raw []byte
+		err error
+	)
+	var (
+		expBigInt      = []*big.Int{nil}
+		expFixedBytes  = [][]byte{nil}
+		expSliceBytes  = [][]byte{nil}
+		expU64fromZero = []uint64{1 << (8 * 7), math.MaxUint64}
+	)
+
+	t.Run("Write", func(t *testing.T) {
+		require := require.New(t)
+
+		raw, err = MarshalBinaryAdapter(func(w *Writer) error {
+			for _, v := range expBigInt {
+				require.Panics(func() {
+					w.BigInt(v)
+				})
+			}
+			for _, v := range expFixedBytes {
+				w.FixedBytes(v)
+			}
+			for _, v := range expSliceBytes {
+				w.SliceBytes(v)
+			}
+			for _, v := range expU64fromZero {
+				require.Panics(func() {
+					w.U64fromZero(v)
+				})
+			}
+			return nil
+		})
+		require.NoError(err)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		require := require.New(t)
+
+		err = UnmarshalBinaryAdapter(raw, func(r *Reader) error {
+			for _, _ = range expBigInt {
+				// skip
+			}
+			for i, exp := range expFixedBytes {
+				got := make([]byte, len(exp))
+				r.FixedBytes(got)
+				require.NotEqual(exp, got, i)
+				require.Equal(len(exp), len(got), i)
+			}
+			for i, exp := range expSliceBytes {
+				got := r.SliceBytes()
+				require.NotEqual(exp, got, i)
+				require.Equal(len(exp), len(got), i)
+			}
+			for _, _ = range expU64fromZero {
+				// skip
+			}
+			return nil
+		})
+		require.NoError(err)
+	})
+}
+
+func randBytes(n int) []byte {
+	bb := make([]byte, n)
+	_, err := rand.Read(bb)
+	if err != nil {
+		panic(err)
+	}
+	return bb
+}

--- a/utils/cser/read_writer.go
+++ b/utils/cser/read_writer.go
@@ -84,8 +84,7 @@ func readUint64BitCompact(bytesR *fast.Reader, size int) uint64 {
 }
 
 func (r *Reader) U8() uint8 {
-	buf := r.BytesR.Read(1)
-	return buf[0]
+	return r.BytesR.ReadByte()
 }
 
 func (w *Writer) U8(v uint8) {

--- a/utils/cser/read_writer.go
+++ b/utils/cser/read_writer.go
@@ -170,6 +170,13 @@ func (r *Reader) U64fromZero() uint64 {
 }
 
 func (w *Writer) U64fromZero(v uint64) {
+	const max = 1<<(8*7) - 1
+	if v > max {
+		// Note: the true fix is to increase bitsForSize,
+		// but it will lead to the need to change existing data.
+		// So just limit max value.
+		panic("Value too big")
+	}
 	w.writeU64_bits(0, 3, v)
 }
 

--- a/utils/cser/read_writer.go
+++ b/utils/cser/read_writer.go
@@ -165,16 +165,13 @@ func (w *Writer) I64(v int64) {
 	}
 }
 
-func (r *Reader) U64fromZero() uint64 {
+func (r *Reader) U56() uint64 {
 	return r.readU64_bits(0, 3)
 }
 
-func (w *Writer) U64fromZero(v uint64) {
+func (w *Writer) U56(v uint64) {
 	const max = 1<<(8*7) - 1
 	if v > max {
-		// Note: the true fix is to increase bitsForSize,
-		// but it will lead to the need to change existing data.
-		// So just limit max value.
 		panic("Value too big")
 	}
 	w.writeU64_bits(0, 3, v)
@@ -204,7 +201,7 @@ func (w *Writer) FixedBytes(v []byte) {
 
 func (r *Reader) SliceBytes() []byte {
 	// read slice size
-	size := r.U64fromZero()
+	size := r.U56()
 	buf := make([]byte, size)
 	// read slice content
 	r.FixedBytes(buf)
@@ -213,7 +210,7 @@ func (r *Reader) SliceBytes() []byte {
 
 func (w *Writer) SliceBytes(v []byte) {
 	// write slice size
-	w.U64fromZero(uint64(len(v)))
+	w.U56(uint64(len(v)))
 	// write slice content
 	w.FixedBytes(v)
 }

--- a/utils/cser/read_writer.go
+++ b/utils/cser/read_writer.go
@@ -23,6 +23,15 @@ type Reader struct {
 	BytesR *fast.Reader
 }
 
+func NewWriter() *Writer {
+	bbits := &bits.Array{Bytes: make([]byte, 0, 32)}
+	bbytes := make([]byte, 0, 200)
+	return &Writer{
+		BitsW:  bits.NewWriter(bbits),
+		BytesW: fast.NewWriter(bbytes),
+	}
+}
+
 func writeUint64Compact(bytesW *fast.Writer, v uint64) {
 	for i := 0; ; i++ {
 		chunk := v & 0b01111111
@@ -100,14 +109,6 @@ func (r *Reader) readU64_bits(minSize int, bitsForSize int) uint64 {
 func (w *Writer) writeU64_bits(minSize int, bitsForSize int, v uint64) {
 	size := writeUint64BitCompact(w.BytesW, v, minSize)
 	w.BitsW.Write(bitsForSize, uint(size-minSize))
-}
-
-func (r *Reader) readU64_var() uint64 {
-	return readUint64Compact(r.BytesR)
-}
-
-func (w *Writer) writeU64_var(v uint64) {
-	writeUint64Compact(w.BytesW, v)
 }
 
 func (r *Reader) U16() uint16 {

--- a/utils/cser/read_writer_test.go
+++ b/utils/cser/read_writer_test.go
@@ -1,0 +1,97 @@
+package cser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Fantom-foundation/go-opera/utils/bits"
+	"github.com/Fantom-foundation/go-opera/utils/fast"
+)
+
+func TestUint64Compact(t *testing.T) {
+	require := require.New(t)
+	var (
+		canonical    = []byte{0b01111111, 0b11111111}
+		nonCanonical = []byte{0b01111111, 0b01111111, 0b10000000}
+	)
+
+	r := fast.NewReader(canonical)
+	got := readUint64Compact(r)
+	require.Equal(uint64(0x3fff), got)
+
+	r = fast.NewReader(nonCanonical)
+	require.Panics(func() {
+		_ = readUint64Compact(r)
+	})
+}
+
+func TestUint64BitCompact(t *testing.T) {
+	require := require.New(t)
+	var (
+		canonical    = []byte{0b11111111, 0b00111111}
+		nonCanonical = []byte{0b01111111, 0b01111111, 0b00000000}
+	)
+
+	r := fast.NewReader(canonical)
+	got := readUint64BitCompact(r, len(canonical))
+	require.Equal(uint64(0x3fff), got)
+
+	r = fast.NewReader(nonCanonical)
+	require.Panics(func() {
+		_ = readUint64BitCompact(r, len(nonCanonical))
+	})
+}
+
+func TestI64(t *testing.T) {
+	require := require.New(t)
+
+	w := NewWriter()
+
+	canonical := w.I64
+	nonCanonical := func(v int64) {
+		w.Bool(v <= 0)
+		if v < 0 {
+			w.U64(uint64(-v))
+		} else {
+			w.U64(uint64(v))
+		}
+	}
+
+	canonical(0)
+	nonCanonical(0)
+
+	r := &Reader{
+		BitsR:  bits.NewReader(w.BitsW.Array),
+		BytesR: fast.NewReader(w.BytesW.Bytes()),
+	}
+
+	got := r.I64()
+	require.Zero(got)
+
+	require.Panics(func() {
+		_ = r.I64()
+	})
+}
+
+func TestPaddedBytes(t *testing.T) {
+	require := require.New(t)
+
+	var data = []struct {
+		In  []byte
+		N   int
+		Exp []byte
+	}{
+		{In: nil, N: 0, Exp: nil},
+		{In: []byte{}, N: 0, Exp: []byte{}},
+		{In: nil, N: 1, Exp: []byte{0}},
+		{In: []byte{}, N: 1, Exp: []byte{0}},
+		{In: []byte{10, 20}, N: 1, Exp: []byte{10, 20}},
+		{In: []byte{10, 20}, N: 4, Exp: []byte{0, 0, 10, 20}},
+	}
+
+	for i, d := range data {
+		got := PaddedBytes(d.In, d.N)
+		require.Equal(d.Exp, got, i)
+	}
+}

--- a/utils/fast/buffer_test.go
+++ b/utils/fast/buffer_test.go
@@ -1,6 +1,8 @@
 package fast
 
 import (
+	"bytes"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,5 +43,46 @@ func TestBuffer(t *testing.T) {
 		got := r.Read(len(bb))
 		require.Equal(bb, got)
 		require.True(r.Empty())
+	})
+}
+
+func Benchmark(b *testing.B) {
+	b.Run("Write", func(b *testing.B) {
+		b.Run("Std", func(b *testing.B) {
+			w := bytes.NewBuffer(make([]byte, 0, b.N))
+			for i := 0; i < b.N; i++ {
+				w.WriteByte(byte(i))
+			}
+			require.Equal(b, b.N, len(w.Bytes()))
+		})
+		b.Run("Fast", func(b *testing.B) {
+			w := NewWriter(make([]byte, 0, b.N))
+			for i := 0; i < b.N; i++ {
+				w.WriteByte(byte(i))
+			}
+			require.Equal(b, b.N, len(w.Bytes()))
+		})
+	})
+
+	b.Run("Read", func(b *testing.B) {
+		src := make([]byte, 1000)
+		rand.Read(src)
+
+		b.Run("Std", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				r := bytes.NewReader(src)
+				for j := 0; j < len(src); j++ {
+					_, _ = r.ReadByte()
+				}
+			}
+		})
+		b.Run("Fast", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				r := NewReader(src)
+				for j := 0; j < len(src); j++ {
+					_ = r.ReadByte()
+				}
+			}
+		})
 	})
 }

--- a/utils/fast/buffer_test.go
+++ b/utils/fast/buffer_test.go
@@ -1,0 +1,45 @@
+package fast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuffer(t *testing.T) {
+	const N = 100
+
+	var (
+		w  *Writer
+		r  *Reader
+		bb = []byte{0, 0, 0xFF, 9, 0}
+	)
+
+	t.Run("Writer", func(t *testing.T) {
+		require := require.New(t)
+
+		w = NewWriter(make([]byte, 0, N/2))
+		for i := byte(0); i < N; i++ {
+			w.WriteByte(i)
+		}
+		require.Equal(N, len(w.Bytes()))
+		w.Write(bb)
+		require.Equal(N+len(bb), len(w.Bytes()))
+	})
+
+	t.Run("Reader", func(t *testing.T) {
+		require := require.New(t)
+
+		r = NewReader(w.Bytes())
+		require.Equal(N+len(bb), len(r.Bytes()))
+		require.False(r.Empty())
+		for exp := byte(0); exp < N; exp++ {
+			got := r.ReadByte()
+			require.Equal(exp, got)
+		}
+		require.Equal(N, r.Position())
+		got := r.Read(len(bb))
+		require.Equal(bb, got)
+		require.True(r.Empty())
+	})
+}


### PR DESCRIPTION
Improves the test coverage to 100%.
Also includes noncritical fix of `Writer.U64fromZero()`.