### PR TITLE
Fix of block txs store

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -197,9 +197,6 @@ func consensusCallbackBeginBlockFn(
 					}
 
 					externalReceipts := evmProcessor.Execute(txs, false)
-					for _, tx := range txs {
-						block.Txs = append(block.Txs, tx.Hash())
-					}
 
 					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
 					block.SkippedTxs = skippedTxs

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -197,8 +197,11 @@ func consensusCallbackBeginBlockFn(
 					}
 
 					externalReceipts := evmProcessor.Execute(txs, false)
-					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
+					for _, tx := range txs {
+						block.Txs = append(block.Txs, tx.Hash())
+					}
 
+					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
 					block.SkippedTxs = skippedTxs
 					block.Root = hash.Hash(evmBlock.Root)
 					block.GasUsed = evmBlock.GasUsed

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -32,8 +32,7 @@ func (s *Store) migrateData() error {
 func (s *Store) migrations() *migration.Migration {
 	return migration.
 		Begin("opera-gossip-store").
-		Next("used gas recovery", s.dataRecovery_UsedGas).
-		Next("block's txs recovery", s.dataRecovery_BlocksTxs)
+		Next("used gas recovery", s.dataRecovery_UsedGas)
 }
 
 func (s *Store) dataRecovery_UsedGas() error {
@@ -79,34 +78,6 @@ func (s *Store) dataRecovery_UsedGas() error {
 		}
 		if fixed {
 			s.EvmStore().SetReceipts(n, rr)
-		}
-	}
-
-	return nil
-}
-
-func (s *Store) dataRecovery_BlocksTxs() error {
-	start := s.GetGenesisBlockIndex()
-	if start == nil {
-		return fmt.Errorf("genesis block index is not set")
-	}
-
-	for n := *start + 1; true; n++ {
-		b := s.GetBlock(n)
-		if b == nil {
-			break
-		}
-
-		var fixed bool
-		for _, id := range b.Events {
-			e := s.GetEventPayload(id)
-			for _, tx := range e.Txs() {
-				b.Txs = append(b.Txs, tx.Hash())
-				fixed = true
-			}
-		}
-		if fixed {
-			s.SetBlock(n, b)
 		}
 	}
 

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -15,9 +15,6 @@ func isEmptyDB(db kvdb.Iteratee) bool {
 }
 
 func (s *Store) migrateData() error {
-
-	defer panic("Finish")
-
 	versions := migration.NewKvdbIDStore(s.table.Version)
 	if isEmptyDB(s.mainDB) && isEmptyDB(s.async.mainDB) {
 		// short circuit if empty DB
@@ -100,10 +97,6 @@ func (s *Store) dataRecovery_BlocksTxs() error {
 			break
 		}
 
-		if len(b.Txs) > 0 {
-			panic("Not empty Txs !")
-		}
-
 		var fixed bool
 		for _, id := range b.Events {
 			e := s.GetEventPayload(id)
@@ -112,12 +105,6 @@ func (s *Store) dataRecovery_BlocksTxs() error {
 				fixed = true
 			}
 		}
-
-		rr := s.EvmStore().GetReceipts(n)
-		if len(b.NotSkippedTxs()) != len(rr) {
-			panic("Invalid len(Txs) !")
-		}
-
 		if fixed {
 			s.SetBlock(n, b)
 		}

--- a/inter/block.go
+++ b/inter/block.go
@@ -10,7 +10,7 @@ type Block struct {
 	Time        Timestamp
 	Atropos     hash.Event
 	Events      hash.Events
-	Txs         []common.Hash
+	Txs         []common.Hash // non events txs (genesis)
 	InternalTxs []common.Hash
 	SkippedTxs  []uint32 // indexes of skipped txs, starting from first tx of first event, ending with last tx of last event
 	GasUsed     uint64
@@ -19,25 +19,6 @@ type Block struct {
 
 func (b *Block) EstimateSize() int {
 	return (len(b.Events)+len(b.InternalTxs)+len(b.Txs)+1+1)*32 + len(b.SkippedTxs)*4 + 8 + 8
-}
-
-func (b *Block) NotSkippedTxs() []common.Hash {
-	txs := append(b.InternalTxs, b.Txs...)
-
-	if len(b.SkippedTxs) == 0 {
-		// short circuit if nothing to skip
-		return txs
-	}
-	skipCount := 0
-	res := make([]common.Hash, 0, len(txs))
-	for i, tx := range txs {
-		if skipCount < len(b.SkippedTxs) && b.SkippedTxs[skipCount] == uint32(i) {
-			skipCount++
-		} else {
-			res = append(res, tx)
-		}
-	}
-	return res
 }
 
 func FilterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {


### PR DESCRIPTION
Removes wrong and unused method `NotSkippedTxs()` of `inter.Block`.