### PR TITLE
Fix isCheater API field

### DIFF
--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -546,14 +546,14 @@ func (b *EthAPIBackend) extendStaker(stakerID idx.ValidatorID, staker *sfcapi.Sf
 		staker.DelegatedMe = new(big.Int)
 	}
 	staker.IsValidator = es.Validators.Exists(stakerID)
+	if staker.Status == 1 {
+		staker.Status = 0
+	}
 	if staker.Status == drivertype.DoublesignBit {
 		staker.Status = sfcapi.ForkBit
 	}
 	if staker.Status == 1<<3 {
 		staker.Status = sfcapi.OfflineBit
-	}
-	if staker.Status == 1 {
-		staker.Status = 0
 	}
 	return staker
 }


### PR DESCRIPTION
- Fix isCheater API field in the deprecated `sfc` namespace for methods `getStaker`, `getStakerByAddress`, `getStakers`