### PR TITLE
Check genesis hash for Opera mainnet and testnet

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Fantom-foundation/lachesis-base/abft"
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -26,6 +27,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/gossip/gasprice"
 	"github.com/Fantom-foundation/go-opera/integration"
 	"github.com/Fantom-foundation/go-opera/integration/makegenesis"
+	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
 	futils "github.com/Fantom-foundation/go-opera/utils"
 	"github.com/Fantom-foundation/go-opera/vecmt"
@@ -74,6 +76,11 @@ var (
 		Name:  "genesis",
 		Usage: "'path to genesis file' - sets the network genesis configuration.",
 	}
+
+	AllowedOperaGenesisHashes = map[uint64]hash.Hash{
+		opera.MainNetworkID: hash.HexToHash("0x4a53c5445584b3bfc20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4"),
+		opera.TestNetworkID: hash.HexToHash("0xc4a5fc96e575a16a9a0c7349d44dc4d0f602a54e0a8543360c2fee4c3937b49e"),
+	}
 )
 
 const (
@@ -106,11 +113,12 @@ type config struct {
 
 func (c *config) AppConfigs() integration.Configs {
 	return integration.Configs{
-		Opera:         c.Opera,
-		OperaStore:    c.OperaStore,
-		Lachesis:      c.Lachesis,
-		LachesisStore: c.LachesisStore,
-		VectorClock:   c.VectorClock,
+		Opera:          c.Opera,
+		OperaStore:     c.OperaStore,
+		Lachesis:       c.Lachesis,
+		LachesisStore:  c.LachesisStore,
+		VectorClock:    c.VectorClock,
+		AllowedGenesis: AllowedOperaGenesisHashes,
 	}
 }
 

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -118,21 +118,21 @@ func makeFlushableProducer(rawProducer kvdb.IterableDBProducer) (*flushable.Sync
 	return dbs, nil
 }
 
-func applyGenesis(rawProducer kvdb.DBProducer, inputGenesus InputGenesis, cfg Configs) error {
+func applyGenesis(rawProducer kvdb.DBProducer, inputGenesis InputGenesis, cfg Configs) error {
 	rawDbs := &DummyFlushableProducer{rawProducer}
 	gdb, cdb, genesisStore := getStores(rawDbs, cfg)
 	defer gdb.Close()
 	defer cdb.Close()
 	defer genesisStore.Close()
 	log.Info("Decoding genesis file")
-	err := inputGenesus.Read(genesisStore)
+	err := inputGenesis.Read(genesisStore)
 	if err != nil {
 		return err
 	}
 	log.Info("Applying genesis state")
 	networkID := genesisStore.GetRules().NetworkID
-	if want, ok := cfg.AllowedGenesis[networkID]; ok && want != inputGenesus.Hash {
-		return fmt.Errorf("genesis hash is not allowed for the network %d: want %s, got %s", networkID, want.String(), inputGenesus.Hash.String())
+	if want, ok := cfg.AllowedGenesis[networkID]; ok && want != inputGenesis.Hash {
+		return fmt.Errorf("genesis hash is not allowed for the network %d: want %s, got %s", networkID, want.String(), inputGenesis.Hash.String())
 	}
 	err = rawApplyGenesis(gdb, cdb, genesisStore.GetGenesis(), cfg)
 	if err != nil {

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -35,11 +35,12 @@ func (e *GenesisMismatchError) Error() string {
 }
 
 type Configs struct {
-	Opera         gossip.Config
-	OperaStore    gossip.StoreConfig
-	Lachesis      abft.Config
-	LachesisStore abft.StoreConfig
-	VectorClock   vecmt.IndexConfig
+	Opera          gossip.Config
+	OperaStore     gossip.StoreConfig
+	Lachesis       abft.Config
+	LachesisStore  abft.StoreConfig
+	VectorClock    vecmt.IndexConfig
+	AllowedGenesis map[uint64]hash.Hash
 }
 
 type InputGenesis struct {
@@ -117,18 +118,22 @@ func makeFlushableProducer(rawProducer kvdb.IterableDBProducer) (*flushable.Sync
 	return dbs, nil
 }
 
-func applyGenesis(rawProducer kvdb.DBProducer, readGenesisStore func(*genesisstore.Store) error, cfg Configs) error {
+func applyGenesis(rawProducer kvdb.DBProducer, inputGenesus InputGenesis, cfg Configs) error {
 	rawDbs := &DummyFlushableProducer{rawProducer}
 	gdb, cdb, genesisStore := getStores(rawDbs, cfg)
 	defer gdb.Close()
 	defer cdb.Close()
 	defer genesisStore.Close()
 	log.Info("Decoding genesis file")
-	err := readGenesisStore(genesisStore)
+	err := inputGenesus.Read(genesisStore)
 	if err != nil {
 		return err
 	}
 	log.Info("Applying genesis state")
+	networkID := genesisStore.GetRules().NetworkID
+	if want, ok := cfg.AllowedGenesis[networkID]; ok && want != inputGenesus.Hash {
+		return fmt.Errorf("genesis hash is not allowed for the network %d: want %s, got %s", networkID, want.String(), inputGenesus.Hash.String())
+	}
 	err = rawApplyGenesis(gdb, cdb, genesisStore.GetGenesis(), cfg)
 	if err != nil {
 		return err
@@ -153,7 +158,7 @@ func makeEngine(rawProducer kvdb.IterableDBProducer, inputGenesis InputGenesis, 
 			return nil, nil, nil, nil, nil, gossip.BlockProc{}, fmt.Errorf("failed to close existing databases: %v", err)
 		}
 
-		err = applyGenesis(rawProducer, inputGenesis.Read, cfg)
+		err = applyGenesis(rawProducer, inputGenesis, cfg)
 		if err != nil {
 			return nil, nil, nil, nil, nil, gossip.BlockProc{}, fmt.Errorf("failed to apply genesis state: %v", err)
 		}
@@ -189,6 +194,11 @@ func makeEngine(rawProducer kvdb.IterableDBProducer, inputGenesis InputGenesis, 
 	engine, vecClock, blockProc, err := rawMakeEngine(gdb, cdb, genesisStore.GetGenesis(), cfg, false)
 	if err != nil {
 		err = fmt.Errorf("failed to make engine: %v", err)
+		return nil, nil, nil, nil, nil, gossip.BlockProc{}, err
+	}
+
+	if *gdb.GetGenesisHash() != inputGenesis.Hash {
+		err = fmt.Errorf("genesis hash mismatch with genesis file header: %s != %s", gdb.GetGenesisHash().String(), inputGenesis.Hash.String())
 		return nil, nil, nil, nil, nil, gossip.BlockProc{}, err
 	}
 


### PR DESCRIPTION
- Check genesis hash for Opera mainnet and testnet to prevent usage of a malformed genesis file