### PR TITLE
Optimize storage of DAG heads and last events

### DIFF
--- a/cmd/opera/launcher/check.go
+++ b/cmd/opera/launcher/check.go
@@ -52,6 +52,7 @@ func checkEvm(ctx *cli.Context) error {
 
 	log.Info("Checking every node hash")
 	nodeIt := evmt.NewIterator(nil, nil)
+	defer nodeIt.Release()
 	for nodeIt.Next() {
 		if len(nodeIt.Key()) != 32 {
 			continue
@@ -64,6 +65,7 @@ func checkEvm(ctx *cli.Context) error {
 
 	log.Info("Checking every code hash")
 	codeIt := table.New(evmt, []byte("c")).NewIterator(nil, nil)
+	defer codeIt.Release()
 	for codeIt.Next() {
 		if len(codeIt.Key()) != 32 {
 			continue
@@ -76,6 +78,7 @@ func checkEvm(ctx *cli.Context) error {
 
 	log.Info("Checking every preimage")
 	preimageIt := table.New(evmt, []byte("secure-key-")).NewIterator(nil, nil)
+	defer preimageIt.Release()
 	for preimageIt.Next() {
 		if len(preimageIt.Key()) != 32 {
 			continue

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -3,6 +3,8 @@ package gossip
 import (
 	"sync/atomic"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
@@ -59,4 +61,8 @@ func (ew *emitterWorld) IsSynced() bool {
 
 func (ew *emitterWorld) PeersNum() int {
 	return ew.s.pm.peers.Len()
+}
+
+func (ew *emitterWorld) GetHeads(epoch idx.Epoch) hash.Events {
+	return ew.Store.GetHeadsSlice(epoch)
 }

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -66,3 +66,7 @@ func (ew *emitterWorld) PeersNum() int {
 func (ew *emitterWorld) GetHeads(epoch idx.Epoch) hash.Events {
 	return ew.Store.GetHeadsSlice(epoch)
 }
+
+func (ew *emitterWorld) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) *hash.Event {
+	return ew.Store.GetLastEvent(epoch, from)
+}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -189,7 +189,7 @@ func (b *EthAPIBackend) GetHeads(ctx context.Context, epoch rpc.BlockNumber) (he
 	}
 
 	if requested == current {
-		heads = b.svc.store.GetHeads(requested)
+		heads = b.svc.store.GetHeadsSlice(requested)
 	} else {
 		err = errors.New("heads for previous epochs are not available")
 		return

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -188,6 +188,10 @@ func (s *Store) Commit() error {
 	// Flush the DBs
 	s.FlushBlockEpochState()
 	s.FlushHighestLamport()
+	es := s.getAnyEpochStore()
+	if es != nil {
+		es.FlushHeads()
+	}
 	return s.dbs.Flush(flushID)
 }
 

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -191,6 +191,7 @@ func (s *Store) Commit() error {
 	es := s.getAnyEpochStore()
 	if es != nil {
 		es.FlushHeads()
+		es.FlushLastEvents()
 	}
 	return s.dbs.Flush(flushID)
 }

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -54,6 +54,7 @@ func (s *Store) GetBlock(n idx.Block) *inter.Block {
 
 func (s *Store) ForEachBlock(fn func(index idx.Block, block *inter.Block)) {
 	it := s.table.Blocks.NewIterator(nil, nil)
+	defer it.Release()
 	for it.Next() {
 		var block inter.Block
 		err := rlp.DecodeBytes(it.Value(), &block)

--- a/gossip/store_epoch.go
+++ b/gossip/store_epoch.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/skiperrors"
@@ -27,12 +26,13 @@ type (
 		epoch idx.Epoch
 		db    kvdb.DropableStore
 		table struct {
-			Tips     kvdb.Store `table:"t"`
-			Heads    kvdb.Store `table:"H"`
-			DagIndex kvdb.Store `table:"v"`
+			LastEvents kvdb.Store `table:"t"`
+			Heads      kvdb.Store `table:"H"`
+			DagIndex   kvdb.Store `table:"v"`
 		}
 		cache struct {
-			Heads atomic.Value
+			Heads      atomic.Value
+			LastEvents atomic.Value
 		}
 
 		logger.Instance
@@ -48,11 +48,12 @@ func newEpochStore(epoch idx.Epoch, db kvdb.DropableStore) *epochStore {
 	table.MigrateTables(&es.table, db)
 
 	// wrap with skiperrors to skip errors on reading from a dropped DB
-	es.table.Tips = skiperrors.Wrap(es.table.Tips, errDBClosed)
+	es.table.LastEvents = skiperrors.Wrap(es.table.LastEvents, errDBClosed)
 	es.table.Heads = skiperrors.Wrap(es.table.Heads, errDBClosed)
 
-	// load heads cache
+	// load the cache to avoid a race condition
 	es.GetHeads()
+	es.GetLastEvents()
 
 	return es
 }
@@ -113,36 +114,4 @@ func (s *Store) createEpochStore(epoch idx.Epoch) {
 		s.Log.Crit("Filed to open DB", "name", name, "err", err)
 	}
 	s.epochStore.Store(newEpochStore(epoch, db))
-}
-
-// SetLastEvent stores last unconfirmed event from a validator (off-chain)
-func (s *Store) SetLastEvent(epoch idx.Epoch, from idx.ValidatorID, id hash.Event) {
-	es := s.getEpochStore(epoch)
-	if es == nil {
-		return
-	}
-
-	key := from.Bytes()
-	if err := es.table.Tips.Put(key, id.Bytes()); err != nil {
-		s.Log.Crit("Failed to put key-value", "err", err)
-	}
-}
-
-// GetLastEvent returns stored last unconfirmed event from a validator (off-chain)
-func (s *Store) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) *hash.Event {
-	es := s.getEpochStore(epoch)
-	if es == nil {
-		return nil
-	}
-
-	key := from.Bytes()
-	idBytes, err := es.table.Tips.Get(key)
-	if err != nil {
-		s.Log.Crit("Failed to get key-value", "err", err)
-	}
-	if idBytes == nil {
-		return nil
-	}
-	id := hash.BytesToEvent(idBytes)
-	return &id
 }

--- a/gossip/store_event.go
+++ b/gossip/store_event.go
@@ -191,10 +191,11 @@ func (s *Store) SetHighestLamport(lamport idx.Lamport) {
 
 func (s *Store) FlushHighestLamport() {
 	cached, ok := s.getCachedHighestLamport()
-	if ok {
-		err := s.table.HighestLamport.Put([]byte("k"), cached.Bytes())
-		if err != nil {
-			s.Log.Crit("Failed to put key-value", "err", err)
-		}
+	if !ok {
+		return
+	}
+	err := s.table.HighestLamport.Put([]byte("k"), cached.Bytes())
+	if err != nil {
+		s.Log.Crit("Failed to put key-value", "err", err)
 	}
 }

--- a/gossip/store_last_events.go
+++ b/gossip/store_last_events.go
@@ -1,0 +1,118 @@
+package gossip
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+
+	"github.com/Fantom-foundation/go-opera/utils/concurrent"
+)
+
+type sortedLastEvent []byte
+
+func (es *epochStore) getCachedLastEvents() (*concurrent.ValidatorEventsSet, bool) {
+	cache := es.cache.LastEvents.Load()
+	if cache != nil {
+		return cache.(*concurrent.ValidatorEventsSet), true
+	}
+	return nil, false
+}
+
+func (es *epochStore) loadLastEvents() *concurrent.ValidatorEventsSet {
+	res := make(map[idx.ValidatorID]hash.Event, 100)
+
+	b, err := es.table.LastEvents.Get([]byte{})
+	if err != nil {
+		es.Log.Crit("Failed to get key-value", "err", err)
+	}
+	if b == nil {
+		return concurrent.WrapValidatorEventsSet(res)
+	}
+	for i := 0; i < len(b); i += 32 + 4 {
+		res[idx.BytesToValidatorID(b[i:i+4])] = hash.BytesToEvent(b[i+4 : i+4+32])
+	}
+
+	return concurrent.WrapValidatorEventsSet(res)
+}
+
+func (es *epochStore) GetLastEvents() *concurrent.ValidatorEventsSet {
+	cached, ok := es.getCachedLastEvents()
+	if ok {
+		return cached
+	}
+	heads := es.loadLastEvents()
+	if heads == nil {
+		heads = &concurrent.ValidatorEventsSet{}
+	}
+	es.cache.LastEvents.Store(heads)
+	return heads
+}
+
+func (es *epochStore) SetLastEvents(ids *concurrent.ValidatorEventsSet) {
+	es.cache.LastEvents.Store(ids)
+}
+
+func (es *epochStore) FlushLastEvents() {
+	lasts, ok := es.getCachedLastEvents()
+	if !ok {
+		return
+	}
+
+	// sort values for determinism
+	sortedLastEvents := make([]sortedLastEvent, 0, len(lasts.ValidatorEventsSet))
+	for vid, eid := range lasts.ValidatorEventsSet {
+		b := append(vid.Bytes(), eid.Bytes()...)
+		sortedLastEvents = append(sortedLastEvents, b)
+	}
+	sort.Slice(sortedLastEvents, func(i, j int) bool {
+		a, b := sortedLastEvents[i], sortedLastEvents[j]
+		return bytes.Compare(a, b) < 0
+	})
+
+	b := make([]byte, 0, len(sortedLastEvents)*(32+4))
+	for _, head := range sortedLastEvents {
+		b = append(b, head...)
+	}
+
+	if err := es.table.LastEvents.Put([]byte{}, b); err != nil {
+		es.Log.Crit("Failed to put key-value", "err", err)
+	}
+}
+
+// GetLastEvents returns latest connected epoch events from each validator
+func (s *Store) GetLastEvents(epoch idx.Epoch) *concurrent.ValidatorEventsSet {
+	es := s.getEpochStore(epoch)
+	if es == nil {
+		return nil
+	}
+
+	return es.GetLastEvents()
+}
+
+// GetLastEvents returns latest connected epoch event from specified validator
+func (s *Store) GetLastEvent(epoch idx.Epoch, vid idx.ValidatorID) *hash.Event {
+	es := s.getEpochStore(epoch)
+	if es == nil {
+		return nil
+	}
+
+	lasts := s.GetLastEvents(epoch)
+	lasts.RLock()
+	defer lasts.RUnlock()
+	last, ok := lasts.ValidatorEventsSet[vid]
+	if !ok {
+		return nil
+	}
+	return &last
+}
+
+func (s *Store) SetLastEvents(epoch idx.Epoch, ids *concurrent.ValidatorEventsSet) {
+	es := s.getEpochStore(epoch)
+	if es == nil {
+		return
+	}
+
+	es.SetLastEvents(ids)
+}

--- a/utils/concurrent/ValidatorEventsSet.go
+++ b/utils/concurrent/ValidatorEventsSet.go
@@ -1,0 +1,19 @@
+package concurrent
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/go-opera/utils/hash"
+)
+
+type ValidatorEventsSet struct {
+	sync.RWMutex
+	hash.ValidatorEventsSet
+}
+
+func WrapValidatorEventsSet(v hash.ValidatorEventsSet) *ValidatorEventsSet {
+	return &ValidatorEventsSet{
+		RWMutex:            sync.RWMutex{},
+		ValidatorEventsSet: v,
+	}
+}

--- a/utils/concurrent/events.go
+++ b/utils/concurrent/events.go
@@ -1,0 +1,19 @@
+package concurrent
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+)
+
+type EventsSet struct {
+	sync.RWMutex
+	hash.EventsSet
+}
+
+func WrapEventsSet(v hash.EventsSet) *EventsSet {
+	return &EventsSet{
+		RWMutex:   sync.RWMutex{},
+		EventsSet: v,
+	}
+}

--- a/utils/hash/validators_events_set.go
+++ b/utils/hash/validators_events_set.go
@@ -1,0 +1,8 @@
+package hash
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+)
+
+type ValidatorEventsSet map[idx.ValidatorID]hash.Event


### PR DESCRIPTION
- DAG heads and last events are stored into DB only during DB committing to reduce a number of DB writes
- DAG heads are stored as `{}` -> `[event IDs]` instead of `event ID` -> `{}`
- DAG last events are stored as `{}` -> `[validator ID and event ID]` instead of  `validator ID` -> `event ID`