### PR TITLE
Add explicit LRU cache for types.Signer

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -49,6 +49,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/go-opera/utils/gsignercache"
 )
 
 var (
@@ -1318,9 +1319,9 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	// because the return value of ChainId is zero for those transactions.
 	var signer types.Signer
 	if tx.Protected() {
-		signer = types.LatestSignerForChainID(tx.ChainId())
+		signer = gsignercache.Wrap(types.LatestSignerForChainID(tx.ChainId()))
 	} else {
-		signer = types.HomesteadSigner{}
+		signer = gsignercache.Wrap(types.HomesteadSigner{})
 	}
 
 	from, _ := types.Sender(signer, tx)
@@ -1497,7 +1498,7 @@ type PublicTransactionPoolAPI struct {
 func NewPublicTransactionPoolAPI(b Backend, nonceLock *AddrLocker) *PublicTransactionPoolAPI {
 	// The signer used by the API should always be the 'latest' known one because we expect
 	// signers to be backwards-compatible with old transactions.
-	signer := types.LatestSignerForChainID(b.ChainConfig().ChainID)
+	signer := gsignercache.Wrap(types.LatestSignerForChainID(b.ChainConfig().ChainID))
 	return &PublicTransactionPoolAPI{b, nonceLock, signer}
 }
 

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -33,6 +33,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/Fantom-foundation/go-opera/utils/gsignercache"
 )
 
 const (
@@ -272,7 +274,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain state
 		config:          config,
 		chainconfig:     chainconfig,
 		chain:           chain,
-		signer:          types.LatestSignerForChainID(chainconfig.ChainID),
+		signer:          gsignercache.Wrap(types.LatestSignerForChainID(chainconfig.ChainID)),
 		pending:         make(map[common.Address]*txList),
 		queue:           make(map[common.Address]*txList),
 		beats:           make(map[common.Address]time.Time),

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,6 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210624070636-329c253feea2
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210712220008-ef39bedfbb55
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210624070636-329c253feea2 h1:5zbHLCFo38Unnm84bXdRGbRm/AVcMVWyhcOF4aTHCQI=
-github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210624070636-329c253feea2/go.mod h1:AItrK6rpGqvJuNAK06OPjCgxS71WP1EmWbn/t9zAM/M=
+github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210712220008-ef39bedfbb55 h1:ii4yI0HhsRXId2FbsNrx+ZBj2VB+JeTkBcgdYdduCnc=
+github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210712220008-ef39bedfbb55/go.mod h1:AItrK6rpGqvJuNAK06OPjCgxS71WP1EmWbn/t9zAM/M=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20210420092627-c16f01e35562 h1:SFcBjyI5dos9JeIRBHnzU88SlVTlEjRbAUrlZ40uWfk=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20210420092627-c16f01e35562/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/opera/genesis/gpos"
 	"github.com/Fantom-foundation/go-opera/utils"
+	"github.com/Fantom-foundation/go-opera/utils/gsignercache"
 )
 
 const (
@@ -82,7 +83,7 @@ func newTestEnv() *testEnv {
 	env := &testEnv{
 		blockProcModules: blockProc,
 		store:            store,
-		signer:           types.NewEIP2930Signer(big.NewInt(int64(genesis.Rules.NetworkID))),
+		signer:           gsignercache.Wrap(types.NewEIP2930Signer(big.NewInt(int64(genesis.Rules.NetworkID)))),
 
 		lastBlock:     1,
 		lastState:     store.GetBlockState().FinalizedStateRoot,

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/logger"
 	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/go-opera/utils/gsignercache"
 	"github.com/Fantom-foundation/go-opera/utils/wgmutex"
 	"github.com/Fantom-foundation/go-opera/valkeystore"
 	"github.com/Fantom-foundation/go-opera/vecmt"
@@ -235,7 +236,7 @@ func newService(config Config, store *Store, signer valkeystore.SignerI, blockPr
 // makeCheckers builds event checkers
 func makeCheckers(heavyCheckCfg heavycheck.Config, chainID *big.Int, heavyCheckReader *HeavyCheckReader, gasPowerCheckReader *GasPowerCheckReader, store *Store) *eventcheck.Checkers {
 	// create signatures checker
-	heavyCheck := heavycheck.New(heavyCheckCfg, heavyCheckReader, types.NewEIP2930Signer(chainID))
+	heavyCheck := heavycheck.New(heavyCheckCfg, heavyCheckReader, gsignercache.Wrap(types.NewEIP2930Signer(chainID)))
 
 	// create gaspower checker
 	gaspowerCheck := gaspowercheck.New(gasPowerCheckReader)
@@ -250,7 +251,7 @@ func makeCheckers(heavyCheckCfg heavycheck.Config, chainID *big.Int, heavyCheckR
 }
 
 func (s *Service) makeEmitter(signer valkeystore.SignerI) *emitter.Emitter {
-	txSigner := types.NewEIP2930Signer(s.store.GetRules().EvmChainConfig().ChainID)
+	txSigner := gsignercache.Wrap(types.NewEIP2930Signer(s.store.GetRules().EvmChainConfig().ChainID))
 
 	return emitter.NewEmitter(s.config.Emitter, emitter.World{
 		External: &emitterWorld{

--- a/utils/gsignercache/global_cache.go
+++ b/utils/gsignercache/global_cache.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	globalCache, _ = lru.New(10000)
+	globalCache, _ = lru.New(40000)
 )
 
 type WlruCache struct {

--- a/utils/gsignercache/global_cache.go
+++ b/utils/gsignercache/global_cache.go
@@ -1,0 +1,32 @@
+package gsignercache
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	globalWlruCache, _ = wlru.New(10000, 10000)
+)
+
+type WlruCache struct {
+	Cache *wlru.Cache
+}
+
+func (w *WlruCache) Add(txid common.Hash, c types.CachedSender) {
+	w.Cache.Add(txid, c, 1)
+}
+
+func (w *WlruCache) Get(txid common.Hash) *types.CachedSender {
+	ic, ok := w.Cache.Get(txid)
+	if !ok {
+		return nil
+	}
+	c := ic.(types.CachedSender)
+	return &c
+}
+
+func Wrap(signer types.Signer) types.Signer {
+	return types.WrapWithCachedSigner(signer, &WlruCache{globalWlruCache})
+}

--- a/utils/gsignercache/global_cache.go
+++ b/utils/gsignercache/global_cache.go
@@ -1,21 +1,21 @@
 package gsignercache
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/utils/wlru"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var (
-	globalWlruCache, _ = wlru.New(10000, 10000)
+	globalCache, _ = lru.New(10000)
 )
 
 type WlruCache struct {
-	Cache *wlru.Cache
+	Cache *lru.Cache
 }
 
 func (w *WlruCache) Add(txid common.Hash, c types.CachedSender) {
-	w.Cache.Add(txid, c, 1)
+	w.Cache.Add(txid, c)
 }
 
 func (w *WlruCache) Get(txid common.Hash) *types.CachedSender {
@@ -28,5 +28,5 @@ func (w *WlruCache) Get(txid common.Hash) *types.CachedSender {
 }
 
 func Wrap(signer types.Signer) types.Signer {
-	return types.WrapWithCachedSigner(signer, &WlruCache{globalWlruCache})
+	return types.WrapWithCachedSigner(signer, &WlruCache{globalCache})
 }


### PR DESCRIPTION
- add wrapper for explicit LRU caching of types.Signer to prevent recovering pubkey twice of the same tx in txpool and DAG events