### PR TITLE
Erase increasing sender's balance in API

### DIFF
--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -302,7 +301,6 @@ func (b *EthAPIBackend) GetTd(_ common.Hash) *big.Int {
 }
 
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg evmcore.Message, state *state.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
-	state.SetBalance(msg.From(), math.MaxBig256)
 	vmError := func() error { return nil }
 
 	if vmConfig == nil {


### PR DESCRIPTION
- the behavior was inherited from API in geth 1.9.8. This PR updates the behavior up to date with geth 1.10.3