### PR TITLE
Increase default MaxTxsPerAddress

### DIFF
--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -56,7 +56,7 @@ func DefaultConfig() Config {
 			ParallelInstanceProtection: 1 * time.Minute,
 		},
 
-		MaxTxsPerAddress: TxTurnNonces / 3,
+		MaxTxsPerAddress: TxTurnNonces,
 
 		MaxParents: 0,
 


### PR DESCRIPTION
- Increase a default maximum number of transactions from a single validator can originate in one event