### PR TITLE
Add defaults for RPCGasCap and RPCTxFeeCap

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -77,6 +77,17 @@ var (
 		Usage: "'path to genesis file' - sets the network genesis configuration.",
 	}
 
+	RPCGlobalGasCapFlag = cli.Uint64Flag{
+		Name:  "rpc.gascap",
+		Usage: "Sets a cap on gas that can be used in ftm_call/estimateGas (0=infinite)",
+		Value: gossip.DefaultConfig(cachescale.Identity).RPCGasCap,
+	}
+	RPCGlobalTxFeeCapFlag = cli.Float64Flag{
+		Name:  "rpc.txfeecap",
+		Usage: "Sets a cap on transaction fee (in FTM) that can be sent via the RPC APIs (0 = no cap)",
+		Value: gossip.DefaultConfig(cachescale.Identity).RPCTxFeeCap,
+	}
+
 	AllowedOperaGenesisHashes = map[uint64]hash.Hash{
 		opera.MainNetworkID: hash.HexToHash("0x4a53c5445584b3bfc20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4"),
 		opera.TestNetworkID: hash.HexToHash("0xc4a5fc96e575a16a9a0c7349d44dc4d0f602a54e0a8543360c2fee4c3937b49e"),
@@ -279,11 +290,11 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) (gossip.Config, 
 	setGPO(ctx, &cfg.GPO)
 	setTxPool(ctx, &cfg.TxPool)
 
-	if ctx.GlobalIsSet(utils.RPCGlobalGasCapFlag.Name) {
-		cfg.RPCGasCap = ctx.GlobalUint64(utils.RPCGlobalGasCapFlag.Name)
+	if ctx.GlobalIsSet(RPCGlobalGasCapFlag.Name) {
+		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCapFlag.Name)
 	}
-	if ctx.GlobalIsSet(utils.RPCGlobalTxFeeCapFlag.Name) {
-		cfg.RPCTxFeeCap = ctx.GlobalFloat64(utils.RPCGlobalTxFeeCapFlag.Name)
+	if ctx.GlobalIsSet(RPCGlobalTxFeeCapFlag.Name) {
+		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCapFlag.Name)
 	}
 
 	err := setValidator(ctx, &cfg.Emitter)

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -146,8 +146,8 @@ func initFlags() {
 		utils.WSPathPrefixFlag,
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
-		utils.RPCGlobalGasCapFlag,
-		utils.RPCGlobalTxFeeCapFlag,
+		RPCGlobalGasCapFlag,
+		RPCGlobalTxFeeCapFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -174,6 +174,9 @@ func DefaultConfig(scale cachescale.Func) Config {
 			WarningIfNotUpgradedEvery: 5 * time.Second,
 		},
 		RPCLogsBloom: true,
+
+		RPCGasCap:   25000000,
+		RPCTxFeeCap: 100, // 100 FTM
 	}
 	cfg.Protocol.Processor.EventsBufferLimit.Num = idx.Event(cfg.Protocol.StreamLeecher.Session.ParallelChunksDownload)*cfg.Protocol.StreamLeecher.Session.DefaultChunkSize.Num + softLimitItems
 	cfg.Protocol.Processor.EventsBufferLimit.Size = uint64(cfg.Protocol.StreamLeecher.Session.ParallelChunksDownload)*cfg.Protocol.StreamLeecher.Session.DefaultChunkSize.Size + 8*opt.MiB


### PR DESCRIPTION
- add default values for RPCGasCap and RPCTxFeeCap
- fix `opera help` output for rpc.gascap and rpc.txfeecap