### PR TITLE
Add saving emitted event ID on disk

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -361,6 +362,9 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 		return nil, err
 	}
 	cfg.Node = nodeConfigWithFlags(ctx, cfg.Node)
+	if cfg.Opera.Emitter.Validator.ID != 0 && len(cfg.Opera.Emitter.PrevEmittedEventFile.Path) == 0 {
+		cfg.Opera.Emitter.PrevEmittedEventFile.Path = cfg.Node.ResolvePath(path.Join("emitter", fmt.Sprintf("last-%d", cfg.Opera.Emitter.Validator.ID)))
+	}
 
 	if err := cfg.Opera.Validate(); err != nil {
 		return nil, err

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -25,6 +25,11 @@ type ValidatorConfig struct {
 	PubKey validatorpk.PubKey
 }
 
+type PrevEmittedEventFile struct {
+	Path     string
+	SyncMode bool
+}
+
 // Config is the configuration of events emitter.
 type Config struct {
 	VersionToPublish string
@@ -43,6 +48,8 @@ type Config struct {
 	EmergencyThreshold  uint64
 
 	TxsCacheInvalidation time.Duration
+
+	PrevEmittedEventFile PrevEmittedEventFile
 }
 
 // DefaultConfig returns the default configurations for the events emitter.

--- a/gossip/emitter/prev_emitted_file.go
+++ b/gossip/emitter/prev_emitted_file.go
@@ -1,0 +1,52 @@
+package emitter
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func openEventFile(path string, isSyncMode bool) *os.File {
+	const dirPerm = 0700
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		log.Crit("Failed to create open event file", "file", path, "err", err)
+	}
+	sync := 0
+	if isSyncMode {
+		sync = os.O_SYNC
+	}
+	fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|sync, 0666)
+	if err != nil {
+		log.Crit("Failed to open event file", "file", path, "err", err)
+	}
+	return fh
+}
+
+func (em *Emitter) writeLastEmittedEventID(id hash.Event) {
+	if em.emittedEventFile == nil {
+		return
+	}
+	_, err := em.emittedEventFile.WriteAt(id.Bytes(), 0)
+	if err != nil {
+		log.Crit("Failed to write event file", "file", em.config.PrevEmittedEventFile.Path, "err", err)
+	}
+}
+
+func (em *Emitter) readLastEmittedEventID() *hash.Event {
+	if em.emittedEventFile == nil {
+		return nil
+	}
+	buf := make([]byte, 32)
+	_, err := em.emittedEventFile.ReadAt(buf, 0)
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		log.Crit("Failed to read event file", "file", em.config.PrevEmittedEventFile.Path, "err", err)
+	}
+	id := hash.BytesToEvent(buf)
+	return &id
+}

--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -51,6 +51,10 @@ func (em *Emitter) currentSyncStatus() doublesign.SyncStatus {
 	if em.world.IsSynced() {
 		s.P2PSynced = em.syncStatus.p2pSynced
 	}
+	prevEmitted := em.readLastEmittedEventID()
+	if prevEmitted != nil && (em.world.GetEvent(*prevEmitted) == nil && em.epoch <= prevEmitted.Epoch()) {
+		s.P2PSynced = time.Time{}
+	}
 	return s
 }
 

--- a/gossip/emitter/world.go
+++ b/gossip/emitter/world.go
@@ -30,6 +30,7 @@ type (
 
 		Check(e *inter.EventPayload, parents inter.Events) error
 		Process(*inter.EventPayload) error
+		Broadcast(*inter.EventPayload)
 		Build(*inter.MutableEventPayload, func()) error
 		DagIndex() *vecmt.Index
 

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -31,16 +31,12 @@ func (ew *emitterWorld) Check(emitted *inter.EventPayload, parents inter.Events)
 }
 
 func (ew *emitterWorld) Process(emitted *inter.EventPayload) error {
-	err := ew.s.processEvent(emitted)
-	if err != nil {
-		ew.s.Log.Crit("Self-event connection failed", "err", err.Error())
-	}
+	return ew.s.processEvent(emitted)
+}
 
-	ew.s.feed.newEmittedEvent.Send(emitted) // PM listens and will broadcast it
-	if err != nil {
-		ew.s.Log.Crit("Failed to post self-event", "err", err.Error())
-	}
-	return nil
+func (ew *emitterWorld) Broadcast(emitted *inter.EventPayload) {
+	// PM listens and will broadcast it
+	ew.s.feed.newEmittedEvent.Send(emitted)
 }
 
 func (ew *emitterWorld) Build(e *inter.MutableEventPayload, onIndexed func()) error {


### PR DESCRIPTION
- emitter saves previous emitted event ID not only into DB but also into in a file. It decreases the chance of an accidental doublesign after a loss of DB data (e.g. after a crash)