### PR TITLE
Update lachesis-base version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Fantom-foundation/go-opera
 go 1.14
 
 require (
-	github.com/Fantom-foundation/lachesis-base v0.0.0-20210420092627-c16f01e35562
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20210721130657-54ad3c8a18c1
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40 // indirect
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210712220008-ef39bedfbb55 h1:ii4yI0HhsRXId2FbsNrx+ZBj2VB+JeTkBcgdYdduCnc=
 github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210712220008-ef39bedfbb55/go.mod h1:AItrK6rpGqvJuNAK06OPjCgxS71WP1EmWbn/t9zAM/M=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210420092627-c16f01e35562 h1:SFcBjyI5dos9JeIRBHnzU88SlVTlEjRbAUrlZ40uWfk=
-github.com/Fantom-foundation/lachesis-base v0.0.0-20210420092627-c16f01e35562/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210721130657-54ad3c8a18c1 h1:FeYLXvgi3MSsWpNJcT1Jzr3LOPWR0c4qEV6C4WY5ISQ=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20210721130657-54ad3c8a18c1/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/eventcheck/queuedcheck"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagprocessor"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagstream"
 	"github.com/Fantom-foundation/lachesis-base/gossip/dagstream/streamleecher"
@@ -310,8 +311,8 @@ func (pm *ProtocolManager) makeProcessor(checkers *eventcheck.Checkers) *dagproc
 			},
 
 			CheckParents: bufferedCheck,
-			CheckParentless: func(inEvents dag.Events, checked func(ee dag.Events, errs []error)) {
-				_ = parentlessChecker.Enqueue(inEvents, checked)
+			CheckParentless: func(tasks []queuedcheck.EventTask, checked func([]queuedcheck.EventTask)) {
+				_ = parentlessChecker.Enqueue(tasks, checked)
 			},
 			OnlyInterested: pm.onlyInterestedEvents,
 		},


### PR DESCRIPTION
- update heavychecker and pararentless checker to use queuedcheck.EventTask from the latest lachesis-base version