### PR TITLE
Optimize cache sizes

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -98,7 +98,8 @@ var (
 const (
 	// DefaultCacheSize is calculated as memory consumption in a worst case scenario with default configuration
 	// Average memory consumption might be 3-5 times lower than the maximum
-	DefaultCacheSize = 3072
+	DefaultCacheSize  = 3200
+	ConstantCacheSize = 1024
 )
 
 // These settings ensure that TOML keys use the same names as Go struct fields.
@@ -333,8 +334,8 @@ func cacheScaler(ctx *cli.Context) cachescale.Func {
 		log.Crit("Invalid flag", "flag", CacheFlag.Name, "err", fmt.Sprintf("minimum cache size is %d MB", DefaultCacheSize))
 	}
 	return cachescale.Ratio{
-		Base:   DefaultCacheSize,
-		Target: uint64(totalCache),
+		Base:   DefaultCacheSize - ConstantCacheSize,
+		Target: uint64(totalCache - ConstantCacheSize),
 	}
 }
 

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -233,7 +233,7 @@ func DefaultStoreConfig(scale cachescale.Func) StoreConfig {
 			BlocksSize: scale.U(512 * opt.KiB),
 		},
 		EVM:                 evmstore.DefaultStoreConfig(scale),
-		MaxNonFlushedSize:   22 * opt.MiB,
+		MaxNonFlushedSize:   17*opt.MiB + scale.I(5*opt.MiB),
 		MaxNonFlushedPeriod: 30 * time.Minute,
 	}
 }
@@ -255,9 +255,9 @@ func LiteStoreConfig() StoreConfig {
 
 func DefaultPeerCacheConfig(scale cachescale.Func) PeerCacheConfig {
 	return PeerCacheConfig{
-		MaxKnownTxs:    scale.I(24576),
-		MaxKnownEvents: scale.I(24576),
-		MaxQueuedItems: scale.Events(4096),
-		MaxQueuedSize:  scale.U64(protocolMaxMsgSize + 1024),
+		MaxKnownTxs:    24576*3/4 + scale.I(24576/4),
+		MaxKnownEvents: 24576*3/4 + scale.I(24576/4),
+		MaxQueuedItems: 4096*3/4 + scale.Events(4096/4),
+		MaxQueuedSize:  protocolMaxMsgSize*3/4 + 1024 + scale.U64(protocolMaxMsgSize/4),
 	}
 }

--- a/integration/db.go
+++ b/integration/db.go
@@ -47,7 +47,7 @@ func CheckDBList(names []string) error {
 
 func dbCacheSize(name string, scale func(int) int) int {
 	if name == "gossip" {
-		return scale(64 * opt.MiB)
+		return scale(128 * opt.MiB)
 	}
 	if name == "lachesis" {
 		return scale(4 * opt.MiB)


### PR DESCRIPTION
- increase LevelDB cache size for the `gossip` DB
- MaxNonFlushedSize partially depends on `--cache` flag
- PeerCacheConfig only partially depends on `--cache` flag
- `--cache` flag takes into consideration a static cache size, which isn't configurable