### PR TITLE
getLogs limit

### DIFF
--- a/gossip/config.go
+++ b/gossip/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/gossip/blockproc/verwatcher"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
+	"github.com/Fantom-foundation/go-opera/gossip/filters"
 	"github.com/Fantom-foundation/go-opera/gossip/gasprice"
 )
 
@@ -51,10 +52,13 @@ type (
 
 		PeerCache PeerCacheConfig
 	}
+
 	// Config for the gossip service.
 	Config struct {
 		Emitter emitter.Config
 		TxPool  evmcore.TxPoolConfig
+
+		FiltersAPI filters.Config
 
 		TxIndex bool // Whether to enable indexing transactions and receipts or not
 
@@ -82,6 +86,7 @@ type (
 
 		RPCLogsBloom bool
 	}
+
 	StoreCacheConfig struct {
 		// Cache size for full events.
 		EventsNum  int
@@ -116,6 +121,8 @@ func DefaultConfig(scale cachescale.Func) Config {
 	cfg := Config{
 		Emitter: emitter.DefaultConfig(),
 		TxPool:  evmcore.DefaultTxPoolConfig,
+
+		FiltersAPI: filters.DefaultConfig(),
 
 		TxIndex: true,
 

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -19,6 +19,7 @@ package filters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -33,6 +34,10 @@ import (
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/topicsdb"
 )
+
+const maxBlocksRange = 5000
+
+var ErrTooWideBlocksRange = fmt.Errorf("too wide blocks range, the limit is %d", maxBlocksRange)
 
 type Backend interface {
 	ChainDb() ethdb.Database
@@ -122,6 +127,10 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	end := uint64(f.end)
 	if f.end < 0 {
 		end = head
+	}
+
+	if (end - begin) > maxBlocksRange {
+		return nil, ErrTooWideBlocksRange
 	}
 
 	if isEmpty(f.topics) {

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -164,6 +164,11 @@ func (f *Filter) unindexedLogs(ctx context.Context, begin, end uint64) (logs []*
 		found  []*types.Log
 	)
 	for n := begin; n <= end; n++ {
+		err = ctx.Err()
+		if err != nil {
+			return
+		}
+
 		header, err = f.backend.HeaderByNumber(ctx, rpc.BlockNumber(n))
 		if header == nil || err != nil {
 			return

--- a/gossip/filters/filter_system_test.go
+++ b/gossip/filters/filter_system_test.go
@@ -145,7 +145,7 @@ func TestBlockSubscription(t *testing.T) {
 
 	var (
 		backend = newTestBackend()
-		api     = NewPublicFilterAPI(backend)
+		api     = NewPublicFilterAPI(backend, testConfig())
 
 		net         = makegenesis.FakeGenesisStore(5, big.NewInt(0), big.NewInt(1)).GetGenesis()
 		statedb, _  = state.New(common.Hash{}, state.NewDatabase(backend.db), nil)
@@ -207,7 +207,7 @@ func TestPendingTxFilter(t *testing.T) {
 
 	var (
 		backend = newTestBackend()
-		api     = NewPublicFilterAPI(backend)
+		api     = NewPublicFilterAPI(backend, testConfig())
 
 		transactions = []*types.Transaction{
 			types.NewTransaction(0, common.HexToAddress("0xb794f5ea0ba39494ce83a213fffba74279579268"), new(big.Int), 0, new(big.Int), nil),
@@ -261,7 +261,7 @@ func TestPendingTxFilter(t *testing.T) {
 func TestLogFilterCreation(t *testing.T) {
 	var (
 		backend = newTestBackend()
-		api     = NewPublicFilterAPI(backend)
+		api     = NewPublicFilterAPI(backend, testConfig())
 
 		testCases = []struct {
 			crit    FilterCriteria
@@ -304,7 +304,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 
 	var (
 		backend = newTestBackend()
-		api     = NewPublicFilterAPI(backend)
+		api     = NewPublicFilterAPI(backend, testConfig())
 	)
 
 	// different situations where log filter creation should fail.
@@ -325,7 +325,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 func TestInvalidGetLogsRequest(t *testing.T) {
 	var (
 		backend   = newTestBackend()
-		api       = NewPublicFilterAPI(backend)
+		api       = NewPublicFilterAPI(backend, testConfig())
 		blockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
 
@@ -349,7 +349,7 @@ func TestLogFilter(t *testing.T) {
 
 	var (
 		backend = newTestBackend()
-		api     = NewPublicFilterAPI(backend)
+		api     = NewPublicFilterAPI(backend, testConfig())
 
 		firstAddr      = common.HexToAddress("0x1111111111111111111111111111111111111111")
 		secondAddr     = common.HexToAddress("0x2222222222222222222222222222222222222222")

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -36,6 +36,13 @@ import (
 	"github.com/Fantom-foundation/go-opera/utils/adapters/ethdb2kvdb"
 )
 
+func testConfig() Config {
+	return Config{
+		IndexedLogsBlockRangeLimit:   1000,
+		UnindexedLogsBlockRangeLimit: 1000,
+	}
+}
+
 func makeReceipt(addr common.Address) *types.Receipt {
 	receipt := types.NewReceipt(nil, false, 0)
 	receipt.Logs = []*types.Log{
@@ -94,7 +101,7 @@ func BenchmarkFilters(b *testing.B) {
 	}
 	b.ResetTimer()
 
-	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil)
+	filter := NewRangeFilter(backend, testConfig(), 0, -1, []common.Address{addr1, addr2, addr3, addr4}, nil)
 
 	for i := 0; i < b.N; i++ {
 		logs, _ := filter.Logs(context.Background())
@@ -185,7 +192,7 @@ func TestFilters(t *testing.T) {
 		err    error
 	)
 
-	filter = NewRangeFilter(backend, 0, -1, []common.Address{addr}, [][]common.Hash{{hash1, hash2, hash3, hash4}})
+	filter = NewRangeFilter(backend, testConfig(), 0, -1, []common.Address{addr}, [][]common.Hash{{hash1, hash2, hash3, hash4}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -194,7 +201,7 @@ func TestFilters(t *testing.T) {
 		t.Error("expected 4 log, got", len(logs))
 	}
 
-	filter = NewRangeFilter(backend, 900, 999, []common.Address{addr}, [][]common.Hash{{hash3}})
+	filter = NewRangeFilter(backend, testConfig(), 900, 999, []common.Address{addr}, [][]common.Hash{{hash3}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -207,7 +214,7 @@ func TestFilters(t *testing.T) {
 		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
 	}
 
-	filter = NewRangeFilter(backend, 990, -1, []common.Address{addr}, [][]common.Hash{{hash3}})
+	filter = NewRangeFilter(backend, testConfig(), 990, -1, []common.Address{addr}, [][]common.Hash{{hash3}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -219,7 +226,7 @@ func TestFilters(t *testing.T) {
 		t.Errorf("expected log[0].Topics[0] to be %x, got %x", hash3, logs[0].Topics[0])
 	}
 
-	filter = NewRangeFilter(backend, 1, 10, nil, [][]common.Hash{{hash1, hash2}})
+	filter = NewRangeFilter(backend, testConfig(), 1, 10, nil, [][]common.Hash{{hash1, hash2}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -229,7 +236,7 @@ func TestFilters(t *testing.T) {
 	}
 
 	failHash := common.BytesToHash([]byte("fail"))
-	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}})
+	filter = NewRangeFilter(backend, testConfig(), 0, -1, nil, [][]common.Hash{{failHash}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -239,7 +246,7 @@ func TestFilters(t *testing.T) {
 	}
 
 	failAddr := common.BytesToAddress([]byte("failmenow"))
-	filter = NewRangeFilter(backend, 0, -1, []common.Address{failAddr}, nil)
+	filter = NewRangeFilter(backend, testConfig(), 0, -1, []common.Address{failAddr}, nil)
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -248,7 +255,7 @@ func TestFilters(t *testing.T) {
 		t.Error("expected 0 log, got", len(logs))
 	}
 
-	filter = NewRangeFilter(backend, 0, -1, nil, [][]common.Hash{{failHash}, {hash1}})
+	filter = NewRangeFilter(backend, testConfig(), 0, -1, nil, [][]common.Hash{{failHash}, {hash1}})
 	logs, err = filter.Logs(context.Background())
 	if err != nil {
 		t.Error(err)

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -327,7 +327,7 @@ func (s *Service) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.EthAPI),
+			Service:   filters.NewPublicFilterAPI(s.EthAPI, s.config.FiltersAPI),
 			Public:    true,
 		}, {
 			Namespace: "net",


### PR DESCRIPTION
Blocks range param limit of getLogs RPC to make them consume less resources.
Default values are:
```
[Opera.FiltersAPI]
IndexedLogsBlockRangeLimit = 99999999
UnindexedLogsBlockRangeLimit = 100
```