### PR TITLE
Filter API uses indexed search when addresses list is specified

### DIFF
--- a/gossip/config.go
+++ b/gossip/config.go
@@ -58,7 +58,7 @@ type (
 		Emitter emitter.Config
 		TxPool  evmcore.TxPoolConfig
 
-		FiltersAPI filters.Config
+		FilterAPI filters.Config
 
 		TxIndex bool // Whether to enable indexing transactions and receipts or not
 
@@ -122,7 +122,7 @@ func DefaultConfig(scale cachescale.Func) Config {
 		Emitter: emitter.DefaultConfig(),
 		TxPool:  evmcore.DefaultTxPoolConfig,
 
-		FiltersAPI: filters.DefaultConfig(),
+		FilterAPI: filters.DefaultConfig(),
 
 		TxIndex: true,
 

--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 	"time"

--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -21,10 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -51,14 +53,14 @@ type filter struct {
 // Config is a provided API params.
 type Config struct {
 	// Block range limit for logs search (indexed).
-	IndexedLogsBlockRangeLimit uint
+	IndexedLogsBlockRangeLimit idx.Block
 	// Block range limit for logs search (unindexed).
-	UnindexedLogsBlockRangeLimit uint
+	UnindexedLogsBlockRangeLimit idx.Block
 }
 
 func DefaultConfig() Config {
 	return Config{
-		IndexedLogsBlockRangeLimit:   99999999,
+		IndexedLogsBlockRangeLimit:   999999999999999999,
 		UnindexedLogsBlockRangeLimit: 100,
 	}
 }

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -136,7 +136,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 
 // indexedLogs returns the logs matching the filter criteria based on topics index.
 func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) ([]*types.Log, error) {
-	if uint(end-begin) > f.config.IndexedLogsBlockRangeLimit {
+	if end-begin > f.config.IndexedLogsBlockRangeLimit {
 		return nil, fmt.Errorf("too wide blocks range, the limit is %d", f.config.IndexedLogsBlockRangeLimit)
 	}
 
@@ -157,7 +157,7 @@ func (f *Filter) indexedLogs(ctx context.Context, begin, end idx.Block) ([]*type
 // indexedLogs returns the logs matching the filter criteria based on raw block
 // iteration.
 func (f *Filter) unindexedLogs(ctx context.Context, begin, end idx.Block) (logs []*types.Log, err error) {
-	if uint(end-begin) > f.config.UnindexedLogsBlockRangeLimit {
+	if end-begin > f.config.UnindexedLogsBlockRangeLimit {
 		return nil, fmt.Errorf("too wide blocks range, the limit is %d", f.config.UnindexedLogsBlockRangeLimit)
 	}
 

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -126,6 +126,9 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 	if f.end < 0 {
 		end = head
 	}
+	if begin > end {
+		return []*types.Log{}, nil
+	}
 
 	if isEmpty(f.topics) && len(f.addresses) == 0 {
 		return f.unindexedLogs(ctx, begin, end)

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -127,7 +127,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		end = head
 	}
 
-	if isEmpty(f.topics) {
+	if isEmpty(f.topics) && len(f.addresses) == 0 {
 		return f.unindexedLogs(ctx, begin, end)
 	} else {
 		return f.indexedLogs(ctx, begin, end)

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -327,7 +327,7 @@ func (s *Service) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.EthAPI, s.config.FiltersAPI),
+			Service:   filters.NewPublicFilterAPI(s.EthAPI, s.config.FilterAPI),
 			Public:    true,
 		}, {
 			Namespace: "net",


### PR DESCRIPTION
- Filter API uses indexed search when addresses list is specified, because topicsdb has the addresses index
- refactor the Filter API config