### PR TITLE
topicsdb fix: block 0

### DIFF
--- a/topicsdb/search_lazy.go
+++ b/topicsdb/search_lazy.go
@@ -59,7 +59,7 @@ func (tt *Index) walkFirst(
 			id := extractLogrecID(it.Key())
 			rec := newLogrec(id, topicCount)
 
-			if blockEnd > 0 && rec.ID.BlockNumber() > blockEnd {
+			if blockStart != nil && rec.ID.BlockNumber() > blockEnd {
 				break
 			}
 


### PR DESCRIPTION
Block index 0 was used as flag for not set blocks range. But it leaded to scan all the blocks when requested only block 0.
The fix changes flag for not set blocks range to other.