### PR TITLE
Fix pending transactions subscription

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/Fantom-foundation/lachesis-base/utils/workers"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -273,10 +272,9 @@ func consensusCallbackBeginBlockFn(
 					store.SetBlockEpochState(bs, es)
 					store.EvmStore().SetCachedEvmBlock(blockCtx.Idx, evmBlock)
 
-					// Notify about new block and txs
+					// Notify about new block
 					if feed != nil {
 						feed.newBlock.Send(evmcore.ChainHeadNotify{Block: evmBlock})
-						feed.newTxs.Send(core.NewTxsEvent{Txs: evmBlock.Transactions})
 						var logs []*types.Log
 						for _, r := range allReceipts {
 							for _, l := range r.Logs {

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -319,16 +318,16 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	return err
 }
 
-func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) notify.Subscription {
+func (b *EthAPIBackend) SubscribeLogsNotify(ch chan<- []*types.Log) notify.Subscription {
 	return b.svc.feed.SubscribeNewLogs(ch)
 }
 
-func (b *EthAPIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) notify.Subscription {
-	return b.svc.feed.SubscribeNewTxs(ch)
+func (b *EthAPIBackend) SubscribeNewBlockNotify(ch chan<- evmcore.ChainHeadNotify) notify.Subscription {
+	return b.svc.feed.SubscribeNewBlock(ch)
 }
 
-func (b *EthAPIBackend) SubscribeNewBlockEvent(ch chan<- evmcore.ChainHeadNotify) notify.Subscription {
-	return b.svc.feed.SubscribeNewBlock(ch)
+func (b *EthAPIBackend) SubscribeNewTxsNotify(ch chan<- evmcore.NewTxsNotify) notify.Subscription {
+	return b.svc.txpool.SubscribeNewTxsNotify(ch)
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
@@ -386,10 +385,6 @@ func (b *EthAPIBackend) Stats() (pending int, queued int) {
 
 func (b *EthAPIBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
 	return b.svc.txpool.Content()
-}
-
-func (b *EthAPIBackend) SubscribeNewTxsNotify(ch chan<- evmcore.NewTxsNotify) notify.Subscription {
-	return b.svc.txpool.SubscribeNewTxsNotify(ch)
 }
 
 // Progress returns current synchronization status of this node

--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	notify "github.com/ethereum/go-ethereum/event"
@@ -42,9 +41,9 @@ type Backend interface {
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 
-	SubscribeNewBlockEvent(ch chan<- evmcore.ChainHeadNotify) notify.Subscription
-	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) notify.Subscription
-	SubscribeLogsEvent(ch chan<- []*types.Log) notify.Subscription
+	SubscribeNewBlockNotify(ch chan<- evmcore.ChainHeadNotify) notify.Subscription
+	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
+	SubscribeLogsNotify(ch chan<- []*types.Log) notify.Subscription
 
 	EvmLogIndex() *topicsdb.Index
 }

--- a/gossip/filters/filter_system.go
+++ b/gossip/filters/filter_system.go
@@ -26,7 +26,6 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -97,7 +96,7 @@ type EventSystem struct {
 	// Channels
 	install   chan *subscription           // install filter for event notification
 	uninstall chan *subscription           // remove filter for event notification
-	txsCh     chan core.NewTxsEvent        // Channel to receive new transactions notify
+	txsCh     chan evmcore.NewTxsNotify    // Channel to receive new transactions notify
 	logsCh    chan []*types.Log            // Channel to receive new log notify
 	blocksCh  chan evmcore.ChainHeadNotify // Channel to receive new chain notify
 }
@@ -113,14 +112,14 @@ func NewEventSystem(backend Backend) *EventSystem {
 		install:   make(chan *subscription),
 		uninstall: make(chan *subscription),
 		blocksCh:  make(chan evmcore.ChainHeadNotify, blocksChanSize),
-		txsCh:     make(chan core.NewTxsEvent, txChanSize),
+		txsCh:     make(chan evmcore.NewTxsNotify, txChanSize),
 		logsCh:    make(chan []*types.Log, logsChanSize),
 	}
 
 	// Subscribe events
-	m.blocksSub = m.backend.SubscribeNewBlockEvent(m.blocksCh)
-	m.txsSub = m.backend.SubscribeNewTxsEvent(m.txsCh)
-	m.logsSub = m.backend.SubscribeLogsEvent(m.logsCh)
+	m.blocksSub = m.backend.SubscribeNewBlockNotify(m.blocksCh)
+	m.txsSub = m.backend.SubscribeNewTxsNotify(m.txsCh)
+	m.logsSub = m.backend.SubscribeLogsNotify(m.logsCh)
 
 	// Make sure none of the subscriptions are empty
 	if m.txsSub == nil || m.logsSub == nil || m.blocksSub == nil {
@@ -315,7 +314,7 @@ func (es *EventSystem) broadcast(filters filterIndex, ev interface{}) {
 				}
 			}
 		}
-	case core.NewTxsEvent:
+	case evmcore.NewTxsNotify:
 		hashes := make([]common.Hash, 0, len(e.Txs))
 		for _, tx := range e.Txs {
 			hashes = append(hashes, tx.Hash())

--- a/gossip/filters/filter_system_test.go
+++ b/gossip/filters/filter_system_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -119,15 +118,15 @@ func (b *testBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types
 	return logs, nil
 }
 
-func (b *testBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) notify.Subscription {
+func (b *testBackend) SubscribeNewTxsNotify(ch chan<- evmcore.NewTxsNotify) notify.Subscription {
 	return b.txsFeed.Subscribe(ch)
 }
 
-func (b *testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) notify.Subscription {
+func (b *testBackend) SubscribeLogsNotify(ch chan<- []*types.Log) notify.Subscription {
 	return b.logsFeed.Subscribe(ch)
 }
 
-func (b *testBackend) SubscribeNewBlockEvent(ch chan<- evmcore.ChainHeadNotify) notify.Subscription {
+func (b *testBackend) SubscribeNewBlockNotify(ch chan<- evmcore.ChainHeadNotify) notify.Subscription {
 	return b.blocksFeed.Subscribe(ch)
 }
 
@@ -223,7 +222,7 @@ func TestPendingTxFilter(t *testing.T) {
 	fid0 := api.NewPendingTransactionFilter()
 
 	time.Sleep(1 * time.Second)
-	backend.txsFeed.Send(core.NewTxsEvent{Txs: transactions})
+	backend.txsFeed.Send(evmcore.NewTxsNotify{Txs: transactions})
 
 	timeout := time.Now().Add(1 * time.Second)
 	for {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/Fantom-foundation/lachesis-base/utils/workers"
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -56,7 +55,6 @@ type ServiceFeed struct {
 	newPack         notify.Feed
 	newEmittedEvent notify.Feed
 	newBlock        notify.Feed
-	newTxs          notify.Feed
 	newLogs         notify.Feed
 }
 
@@ -70,10 +68,6 @@ func (f *ServiceFeed) SubscribeNewEmitted(ch chan<- *inter.EventPayload) notify.
 
 func (f *ServiceFeed) SubscribeNewBlock(ch chan<- evmcore.ChainHeadNotify) notify.Subscription {
 	return f.scope.Track(f.newBlock.Subscribe(ch))
-}
-
-func (f *ServiceFeed) SubscribeNewTxs(ch chan<- core.NewTxsEvent) notify.Subscription {
-	return f.scope.Track(f.newTxs.Subscribe(ch))
 }
 
 func (f *ServiceFeed) SubscribeNewLogs(ch chan<- []*types.Log) notify.Subscription {


### PR DESCRIPTION
Use pending transactions instead of confirmed transactions for the filter subscription API. Fix #168