### PR TITLE
Fix block hashes in subscription API

### DIFF
--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -98,7 +98,7 @@ func ConvertFromEthHeader(h *types.Header) *EvmHeader {
 // EthHeader returns header in ETH format
 func (h *EvmHeader) EthHeader() *types.Header {
 	// NOTE: incomplete conversion
-	return &types.Header{
+	ethHeader := &types.Header{
 		Number:     h.Number,
 		Coinbase:   h.Coinbase,
 		GasLimit:   0xffffffffffff, // don't use h.GasLimit (too much bits) here to avoid parsing issues
@@ -111,6 +111,8 @@ func (h *EvmHeader) EthHeader() *types.Header {
 
 		Difficulty: new(big.Int),
 	}
+	ethHeader.SetHashCache(h.Hash)
+	return ethHeader
 }
 
 // Header is a copy of EvmBlock.EvmHeader.

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,6 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210827160629-07563551b4c0
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.9.7-0.20211011130458-d2c87807503f
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210827160629-07563551b4c0 h1:QeAgGh7NLmzMJcOT2LqxOPfHVHAO6BJsWN897ZXlh6U=
-github.com/Fantom-foundation/go-ethereum v1.9.7-0.20210827160629-07563551b4c0/go.mod h1:AItrK6rpGqvJuNAK06OPjCgxS71WP1EmWbn/t9zAM/M=
+github.com/Fantom-foundation/go-ethereum v1.9.7-0.20211011130458-d2c87807503f h1:ps5G6Qzm0OqYJ7NajgKxpeBBQXwkNP3EQO/ql5KhtJM=
+github.com/Fantom-foundation/go-ethereum v1.9.7-0.20211011130458-d2c87807503f/go.mod h1:AItrK6rpGqvJuNAK06OPjCgxS71WP1EmWbn/t9zAM/M=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20210721130657-54ad3c8a18c1 h1:FeYLXvgi3MSsWpNJcT1Jzr3LOPWR0c4qEV6C4WY5ISQ=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20210721130657-54ad3c8a18c1/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
- types.Header.Hash() returns Atropos ID after being converted from evmcore.EvmHeader, instead of a header hash (Fix #173)