### PR TITLE
Fix of receipt's and log's tx index

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -309,13 +309,7 @@ func consensusCallbackBeginBlockFn(
 						txs = append(txs, e.Txs()...)
 					}
 
-					txs1 := txs[:len(txs)/2]
-					txs2 := txs[len(txs)/2:]
-					externalReceipts1 := evmProcessor.Execute(txs1, false)
-					log.Warn("x--------- ", "splitby", len(txs)/2)
-					externalReceipts2 := evmProcessor.Execute(txs2, false)
-					externalReceipts := append(externalReceipts1, externalReceipts2...)
-					// externalReceipts := evmProcessor.Execute(txs, false)
+					externalReceipts := evmProcessor.Execute(txs, false)
 
 					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
 					block.SkippedTxs = skippedTxs

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -309,7 +309,13 @@ func consensusCallbackBeginBlockFn(
 						txs = append(txs, e.Txs()...)
 					}
 
-					externalReceipts := evmProcessor.Execute(txs, false)
+					txs1 := txs[:len(txs)/2]
+					txs2 := txs[len(txs)/2:]
+					externalReceipts1 := evmProcessor.Execute(txs1, false)
+					log.Warn("x--------- ", "splitby", len(txs)/2)
+					externalReceipts2 := evmProcessor.Execute(txs2, false)
+					externalReceipts := append(externalReceipts1, externalReceipts2...)
+					// externalReceipts := evmProcessor.Execute(txs, false)
 
 					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
 					block.SkippedTxs = skippedTxs

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/ethapi"
 	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/gossip/sfcapi"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/inter/drivertype"
@@ -341,6 +342,10 @@ func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {
 
 func (b *EthAPIBackend) GetPoolTransaction(hash common.Hash) *types.Transaction {
 	return b.svc.txpool.Get(hash)
+}
+
+func (b *EthAPIBackend) GetTxPosition(txHash common.Hash) *evmstore.TxPosition {
+	return b.svc.store.evm.GetTxPosition(txHash)
 }
 
 func (b *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, uint64, uint64, error) {

--- a/gossip/filters/filter_system_test.go
+++ b/gossip/filters/filter_system_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/integration/makegenesis"
 	"github.com/Fantom-foundation/go-opera/topicsdb"
 )
@@ -132,6 +133,10 @@ func (b *testBackend) SubscribeNewBlockNotify(ch chan<- evmcore.ChainHeadNotify)
 
 func (b *testBackend) EvmLogIndex() *topicsdb.Index {
 	return b.logIndex
+}
+
+func (b *testBackend) GetTxPosition(txid common.Hash) *evmstore.TxPosition {
+	return nil
 }
 
 // TestBlockSubscription tests if a block subscription returns block hashes for posted chain notify.


### PR DESCRIPTION
Makes filters restore TxIndex for indexed logs (Fix #189).
Also properly sets of `Receipt.TransactionIndex` but it does not matter because this field is not stored.