### PR TITLE
Fix p2p races

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -758,12 +758,6 @@ func (h *handler) highestPeerProgress() PeerProgress {
 // handle is the callback invoked to manage the life cycle of a peer. When
 // this function terminates, the peer is disconnected.
 func (h *handler) handle(p *peer) error {
-	// Ignore maxPeers if this is a trusted peer
-	if h.peers.Len() >= h.maxPeers && !p.Peer.Info().Network.Trusted {
-		return p2p.DiscTooManyPeers
-	}
-	p.Log().Debug("Peer connected", "name", p.Name())
-
 	// If the peer has a `snap` extension, wait for it to connect so we can have
 	// a uniform initialization/teardown mechanism
 	snap, err := h.peers.WaitSnapExtension(p)
@@ -784,6 +778,12 @@ func (h *handler) handle(p *peer) error {
 		p.Log().Debug("Handshake failed", "err", err)
 		return err
 	}
+
+	// Ignore maxPeers if this is a trusted peer
+	if h.peers.Len() >= h.maxPeers && !p.Peer.Info().Network.Trusted {
+		return p2p.DiscTooManyPeers
+	}
+	p.Log().Debug("Peer connected", "name", p.Name())
 
 	// Register the peer locally
 	if err := h.peers.RegisterPeer(p, snap); err != nil {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -176,6 +176,7 @@ type handler struct {
 	loopsWg sync.WaitGroup
 	wg      sync.WaitGroup
 	peerWG  sync.WaitGroup
+	started sync.WaitGroup
 
 	logger.Instance
 }
@@ -211,6 +212,7 @@ func newHandler(
 
 		Instance: logger.New("PM"),
 	}
+	h.started.Add(1)
 
 	// TODO: configure it
 	var (
@@ -677,6 +679,7 @@ func (h *handler) Start(maxPeers int) {
 	h.brProcessor.Start()
 	h.brSeeder.Start()
 	h.brLeecher.Start()
+	h.started.Done()
 }
 
 func (h *handler) Stop() {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -315,6 +315,8 @@ func MakeProtocols(svc *Service, backend *handler, disc enode.Iterator) []p2p.Pr
 			Version: version,
 			Length:  protocolLengths[version],
 			Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+				// wait until handler has started
+				backend.started.Wait()
 				peer := newPeer(version, p, rw, backend.config.Protocol.PeerCache)
 				defer peer.Close()
 


### PR DESCRIPTION
- wait until hossip.Handler has started before running opera protocol
- raise DiscTooManyPeers after WaitSnapExtension to prevent dangled snap protocol registration