### PR TITLE
ethapi: fix wrong decode tnx issue

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1744,7 +1744,7 @@ func (s *PublicTransactionPoolAPI) FillTransaction(ctx context.Context, args Tra
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
 	tx := new(types.Transaction)
-	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
+	if err := tx.UnmarshalBinary(encodedTx); err != nil {
 		return common.Hash{}, err
 	}
 	return SubmitTransaction(ctx, s.b, tx)


### PR DESCRIPTION
we cannot decode transactions with `rlp.DecodeBytes` anymore, only with `tx.UnmarshalBinary`