### PR TITLE
No parallel snapshot generation

### DIFF
--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -176,7 +176,7 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	}
 	if gen, err := s.store.evm.Snaps.Generating(); gen || err != nil {
 		// never allow fullsync while EVM snap is still generating, as it may lead to a race condition
-		s.Log.Warn("EVM snapshot is not ready during event processing", "gen", gen, "err", gen)
+		s.Log.Warn("EVM snapshot is not ready during event processing", "gen", gen, "err", err)
 		return errDirtyEvmSnap
 	}
 	atomic.StoreUint32(&s.eventBusyFlag, 1)

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -25,6 +25,7 @@ var (
 	errWrongEpochHash   = errors.New("wrong event epoch hash")
 	errNonExistingEpoch = errors.New("epoch doesn't exist")
 	errSameEpoch        = errors.New("epoch hasn't changed")
+	errDirtyEvmSnap     = errors.New("EVM snapshot is dirty")
 )
 
 func (s *Service) buildEvent(e *inter.MutableEventPayload, onIndexed func()) error {
@@ -173,10 +174,10 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	if s.stopped {
 		return errStopped
 	}
-	if s.store.evm.IsEvmSnapshotPaused() {
-		root := s.store.GetBlockState().FinalizedStateRoot
-		s.Log.Warn("Rebuilding state snapshot after a pause", "root", root)
-		s.store.evm.RebuildEvmSnapshot(common.Hash(root))
+	if gen, err := s.store.evm.Snaps.Generating(); gen || err != nil {
+		// never allow fullsync while EVM snap is still generating, as it may lead to a race condition
+		s.Log.Warn("EVM snapshot is not ready during event processing", "gen", gen, "err", gen)
+		return errDirtyEvmSnap
 	}
 	atomic.StoreUint32(&s.eventBusyFlag, 1)
 	defer atomic.StoreUint32(&s.eventBusyFlag, 0)

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -201,11 +201,11 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	}
 
 	// Process LLR votes
-	err := s.ProcessBlockVotes(inter.AsSignedBlockVotes(e))
+	err := s.processBlockVotes(inter.AsSignedBlockVotes(e))
 	if err != nil && err != eventcheck.ErrAlreadyProcessedBVs {
 		return err
 	}
-	err = s.ProcessEpochVote(inter.AsSignedEpochVote(e))
+	err = s.processEpochVote(inter.AsSignedEpochVote(e))
 	if err != nil && err != eventcheck.ErrAlreadyProcessedEV {
 		return err
 	}

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -40,7 +40,7 @@ func (s *Service) processBlockVote(block idx.Block, epoch idx.Epoch, bv hash.Has
 	}
 }
 
-func (s *Service) ProcessBlockVotes(bvs inter.LlrSignedBlockVotes) error {
+func (s *Service) processBlockVotes(bvs inter.LlrSignedBlockVotes) error {
 	// engineMu should be locked here
 	if len(bvs.Val.Votes) == 0 {
 		// short circuit if no records
@@ -75,11 +75,15 @@ func (s *Service) ProcessBlockVotes(bvs inter.LlrSignedBlockVotes) error {
 	}
 	lBVs.Unlock()
 
-	s.mayCommit(false)
 	return nil
 }
 
-func (s *Service) ProcessFullBlockRecord(br ibr.LlrIdxFullBlockRecord) error {
+func (s *Service) ProcessBlockVotes(bvs inter.LlrSignedBlockVotes) error {
+	defer s.mayCommit(false)
+	return s.processBlockVotes(bvs)
+}
+
+func (s *Service) processFullBlockRecord(br ibr.LlrIdxFullBlockRecord) error {
 	// engineMu should NOT be locked here
 	if s.store.HasBlock(br.Idx) {
 		return eventcheck.ErrAlreadyProcessedBR
@@ -140,11 +144,15 @@ func (s *Service) ProcessFullBlockRecord(br ibr.LlrIdxFullBlockRecord) error {
 	}
 	updateLowestBlockToFill(br.Idx, s.store)
 
-	s.mayCommit(false)
 	return nil
 }
 
-func (s *Service) processEpochVote(epoch idx.Epoch, ev hash.Hash, val idx.Validator, vals *pos.Validators, llrs *LlrState) {
+func (s *Service) ProcessFullBlockRecord(br ibr.LlrIdxFullBlockRecord) error {
+	defer s.mayCommit(false)
+	return s.processFullBlockRecord(br)
+}
+
+func (s *Service) processRawEpochVote(epoch idx.Epoch, ev hash.Hash, val idx.Validator, vals *pos.Validators, llrs *LlrState) {
 	newWeight := s.store.AddLlrEpochVoteWeight(epoch, ev, val, vals.Len(), vals.GetWeightByIdx(val))
 	if newWeight >= vals.TotalWeight()/3+1 {
 		wonEr := s.store.GetLlrEpochResult(epoch)
@@ -159,7 +167,7 @@ func (s *Service) processEpochVote(epoch idx.Epoch, ev hash.Hash, val idx.Valida
 	}
 }
 
-func (s *Service) ProcessEpochVote(ev inter.LlrSignedEpochVote) error {
+func (s *Service) processEpochVote(ev inter.LlrSignedEpochVote) error {
 	// engineMu should be locked here
 	if ev.Val.Epoch == 0 {
 		// short circuit if no records
@@ -178,7 +186,7 @@ func (s *Service) ProcessEpochVote(ev inter.LlrSignedEpochVote) error {
 	}
 
 	s.store.ModifyLlrState(func(llrs *LlrState) {
-		s.processEpochVote(ev.Val.Epoch, ev.Val.Vote, es.Validators.GetIdx(vid), es.Validators, llrs)
+		s.processRawEpochVote(ev.Val.Epoch, ev.Val.Vote, es.Validators.GetIdx(vid), es.Validators, llrs)
 	})
 	s.store.SetEpochVote(ev)
 	lEVs := s.store.GetLastEVs()
@@ -189,11 +197,15 @@ func (s *Service) ProcessEpochVote(ev inter.LlrSignedEpochVote) error {
 	}
 	lEVs.Unlock()
 
-	s.mayCommit(false)
 	return nil
 }
 
-func (s *Service) ProcessFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
+func (s *Service) ProcessEpochVote(ev inter.LlrSignedEpochVote) error {
+	defer s.mayCommit(false)
+	return s.processEpochVote(ev)
+}
+
+func (s *Service) processFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
 	// engineMu should NOT be locked here
 	if s.store.HasHistoryBlockEpochState(er.Idx) {
 		return eventcheck.ErrAlreadyProcessedER
@@ -215,8 +227,12 @@ func (s *Service) ProcessFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
 	defer s.engineMu.Unlock()
 	updateLowestEpochToFill(er.Idx, s.store)
 
-	s.mayCommit(false)
 	return nil
+}
+
+func (s *Service) ProcessFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
+	defer s.mayCommit(false)
+	return s.processFullEpochRecord(er)
 }
 
 func updateLowestBlockToFill(block idx.Block, store *Store) {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -365,7 +365,11 @@ func newHandler(
 	h.epProcessor = h.makeEpProcessor(h.checkers)
 	h.epLeecher = epstreamleecher.New(h.config.Protocol.EpStreamLeecher, epstreamleecher.Callbacks{
 		LowestEpochToFetch: func() idx.Epoch {
-			return h.store.GetLlrState().LowestEpochToFill
+			llrs := h.store.GetLlrState()
+			if llrs.LowestEpochToFill < llrs.LowestEpochToDecide {
+				return llrs.LowestEpochToFill
+			}
+			return llrs.LowestEpochToDecide
 		},
 		MaxEpochToFetch: func() idx.Epoch {
 			return h.store.GetLlrState().LowestEpochToDecide + 10000

--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -20,6 +20,7 @@ type syncStatus struct {
 const (
 	ssUnknown syncStage = iota
 	ssSnaps
+	ssEvmSnapGen
 	ssEvents
 )
 
@@ -150,13 +151,17 @@ func (h *handler) txsyncLoop() {
 }
 
 func (h *handler) updateSnapsyncStage() {
-	fullsyncPossible := h.store.evm.HasStateDB(h.store.GetBlockState().FinalizedStateRoot)
+	// never allow fullsync while EVM snap is still generating, as it may lead to a race condition
+	snapGenOngoing, _ := h.store.evm.Snaps.Generating()
+	fullsyncPossible := h.store.evm.HasStateDB(h.store.GetBlockState().FinalizedStateRoot) && !snapGenOngoing
 	// never allow to stop fullsync as it may lead to a race condition due to overwritten EVM snapshot by snapsync
 	snapsyncPossible := h.config.AllowSnapsync && !h.syncStatus.Is(ssEvents)
 	snapsyncNeeded := !fullsyncPossible || time.Since(h.store.GetEpochState().EpochStart.Time()) > snapsyncMinEndAge
 
 	if snapsyncPossible && snapsyncNeeded {
 		h.syncStatus.Set(ssSnaps)
+	} else if snapGenOngoing {
+		h.syncStatus.Set(ssEvmSnapGen)
 	} else if fullsyncPossible {
 		h.syncStatus.Set(ssEvents)
 	}
@@ -196,7 +201,7 @@ func (h *handler) snapsyncStageTick() {
 				h.Log.Error("Failed to result snapsync", "epoch", epoch, "block", bs.LastBlock.Idx, "err", err)
 			} else {
 				h.Log.Info("Snapsync is finalized at", "epoch", epoch, "block", bs.LastBlock.Idx, "root", bs.FinalizedStateRoot)
-				h.syncStatus.Set(ssEvents)
+				h.updateSnapsyncStage()
 			}
 		}
 	}


### PR DESCRIPTION
- allow events processing only after EVM snapshot generation has finished to prevent a non-deterministic result of transactions execution