### PR TITLE
Fix mutation of cached HistoryBlockEpochState values

### DIFF
--- a/gossip/store_decided_state.go
+++ b/gossip/store_decided_state.go
@@ -17,6 +17,7 @@ type BlockEpochState struct {
 }
 
 func (s *Store) SetHistoryBlockEpochState(epoch idx.Epoch, bs iblockproc.BlockState, es iblockproc.EpochState) {
+	bs, es = bs.Copy(), es.Copy()
 	bes := &BlockEpochState{
 		BlockState: &bs,
 		EpochState: &es,
@@ -44,7 +45,9 @@ func (s *Store) GetHistoryBlockEpochState(epoch idx.Epoch) (*iblockproc.BlockSta
 	}
 	// Save to the LRU cache
 	s.cache.BlockEpochStateHistory.Add(epoch, v, nominalSize)
-	return v.BlockState, v.EpochState
+	bs := v.BlockState.Copy()
+	es := v.EpochState.Copy()
+	return &bs, &es
 }
 
 func (s *Store) GetHistoryEpochState(epoch idx.Epoch) *iblockproc.EpochState {

--- a/inter/iblockproc/decided_state.go
+++ b/inter/iblockproc/decided_state.go
@@ -63,9 +63,15 @@ func (bs BlockState) Copy() BlockState {
 	copy(cp.EpochCheaters, bs.EpochCheaters)
 	cp.ValidatorStates = make([]ValidatorBlockState, len(bs.ValidatorStates))
 	copy(cp.ValidatorStates, bs.ValidatorStates)
+	for i := range cp.ValidatorStates {
+		cp.ValidatorStates[i].Originated = new(big.Int).Set(cp.ValidatorStates[i].Originated)
+	}
 	cp.NextValidatorProfiles = make(ValidatorProfiles, len(bs.NextValidatorProfiles))
 	for k, v := range bs.NextValidatorProfiles {
-		cp.NextValidatorProfiles[k] = v
+		cpv := v
+		cpv.Weight = new(big.Int).Set(cpv.Weight)
+		cpv.PubKey = cpv.PubKey.Copy()
+		cp.NextValidatorProfiles[k] = cpv
 	}
 	if bs.DirtyRules != nil {
 		rules := bs.DirtyRules.Copy()
@@ -148,7 +154,10 @@ func (es EpochState) Copy() EpochState {
 	copy(cp.ValidatorStates, es.ValidatorStates)
 	cp.ValidatorProfiles = make(ValidatorProfiles, len(es.ValidatorProfiles))
 	for k, v := range es.ValidatorProfiles {
-		cp.ValidatorProfiles[k] = v
+		cpv := v
+		cpv.Weight = new(big.Int).Set(cpv.Weight)
+		cpv.PubKey = cpv.PubKey.Copy()
+		cp.ValidatorProfiles[k] = cpv
 	}
 	cp.Rules = es.Rules.Copy()
 	return cp

--- a/inter/iblockproc/decided_state.go
+++ b/inter/iblockproc/decided_state.go
@@ -66,13 +66,7 @@ func (bs BlockState) Copy() BlockState {
 	for i := range cp.ValidatorStates {
 		cp.ValidatorStates[i].Originated = new(big.Int).Set(cp.ValidatorStates[i].Originated)
 	}
-	cp.NextValidatorProfiles = make(ValidatorProfiles, len(bs.NextValidatorProfiles))
-	for k, v := range bs.NextValidatorProfiles {
-		cpv := v
-		cpv.Weight = new(big.Int).Set(cpv.Weight)
-		cpv.PubKey = cpv.PubKey.Copy()
-		cp.NextValidatorProfiles[k] = cpv
-	}
+	cp.NextValidatorProfiles = bs.NextValidatorProfiles.Copy()
 	if bs.DirtyRules != nil {
 		rules := bs.DirtyRules.Copy()
 		cp.DirtyRules = &rules
@@ -152,13 +146,7 @@ func (es EpochState) Copy() EpochState {
 	cp := es
 	cp.ValidatorStates = make([]ValidatorEpochState, len(es.ValidatorStates))
 	copy(cp.ValidatorStates, es.ValidatorStates)
-	cp.ValidatorProfiles = make(ValidatorProfiles, len(es.ValidatorProfiles))
-	for k, v := range es.ValidatorProfiles {
-		cpv := v
-		cpv.Weight = new(big.Int).Set(cpv.Weight)
-		cpv.PubKey = cpv.PubKey.Copy()
-		cp.ValidatorProfiles[k] = cpv
-	}
+	cp.ValidatorProfiles = es.ValidatorProfiles.Copy()
 	cp.Rules = es.Rules.Copy()
 	return cp
 }

--- a/inter/iblockproc/profiles.go
+++ b/inter/iblockproc/profiles.go
@@ -2,6 +2,7 @@ package iblockproc
 
 import (
 	"io"
+	"math/big"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
@@ -15,7 +16,10 @@ type ValidatorProfiles map[idx.ValidatorID]drivertype.Validator
 func (vv ValidatorProfiles) Copy() ValidatorProfiles {
 	cp := make(ValidatorProfiles, len(vv))
 	for k, v := range vv {
-		cp[k] = v
+		cpv := v
+		cpv.Weight = new(big.Int).Set(cpv.Weight)
+		cpv.PubKey = cpv.PubKey.Copy()
+		cp[k] = cpv
 	}
 	return cp
 }

--- a/inter/validatorpk/pubkey.go
+++ b/inter/validatorpk/pubkey.go
@@ -32,6 +32,13 @@ func (pk *PubKey) Bytes() []byte {
 	return append([]byte{pk.Type}, pk.Raw...)
 }
 
+func (pk PubKey) Copy() PubKey {
+	return PubKey{
+		Type: pk.Type,
+		Raw:  common.CopyBytes(pk.Raw),
+	}
+}
+
 func FromString(str string) (PubKey, error) {
 	return FromBytes(common.FromHex(str))
 }


### PR DESCRIPTION
- fix race condition caused by mutation of cached BlockEpochState/HistoryBlockEpochState values
`.Copy()` method didn't copy the `Originated` field which gets mutated during block processing. As a result, cached value of HistoryBlockEpochState.BlockState gets mutated, which leads to retrieval of a different ER