### PR TITLE
output log when node start/switch to fullsync mode

### DIFF
--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -164,6 +164,9 @@ func (h *handler) updateSnapsyncStage() {
 	} else if snapGenOngoing {
 		h.syncStatus.Set(ssEvmSnapGen)
 	} else if fullsyncPossibleNow {
+		if !h.syncStatus.Is(ssEvents) {
+			h.Log.Info("Start/Switch to fullsync mode...")
+		}
 		h.syncStatus.Set(ssEvents)
 	}
 }


### PR DESCRIPTION
Output log to let operator know that node start/switch to **fullsync** mode. I can think there're two cases

1. node completed **snapsync** and start to **fullsync** mode
2. operator synced full mode then change to snapsync mode in the command line (`--syncmode=snap`) but node be forced to **fullsync** mode

