### PR TITLE
Fix cached receipt after block processing

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -157,6 +157,7 @@ func applyTransaction(
 
 	// Set the receipt logs.
 	receipt.Logs = logs
+	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 	receipt.BlockHash = blockHash
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())


### PR DESCRIPTION
- block processing skips receipt logs bloom processing which loads to injection of a bloom-less receipt into cache (the test is in #215). After initially cached receipt object got evicted from cache, reading it from disk will lead to calculation of bloom from logs. Receipt bloom is used only for API and isn't written on disk. 