### PR TITLE
Avoid parallel BRs and blocks processing

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -1222,6 +1222,10 @@ func (h *handler) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == BRsStreamResponse:
+		if !h.syncStatus.AcceptBlockRecords() {
+			break
+		}
+
 		msgSize := uint64(msg.Size)
 		var chunk brsChunk
 		if err := msg.Decode(&chunk); err != nil {

--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -55,6 +55,10 @@ func (ss *syncStatus) AcceptEvents() bool {
 	return ss.Is(ssEvents)
 }
 
+func (ss *syncStatus) AcceptBlockRecords() bool {
+	return !ss.Is(ssEvents)
+}
+
 func (ss *syncStatus) AcceptTxs() bool {
 	return ss.MaybeSynced() && ss.Is(ssEvents)
 }
@@ -226,8 +230,10 @@ func (h *handler) snapsyncStageTick() {
 	// resume events downloading if events sync is enabled
 	if h.syncStatus.Is(ssEvents) {
 		h.dagLeecher.Resume()
+		h.brLeecher.Pause()
 	} else {
 		h.dagLeecher.Pause()
+		h.brLeecher.Resume()
 	}
 }
 


### PR DESCRIPTION
Don't allow BRs processing if events processing is allowed. For 2 reasons:
- avoid returning unprocessed blocks (but already indexed by BR processing) in API whose state is not accessible
- reduce number of DB writes, as block processing don't check if block is already written by BR processing and may overwrite the data. Since BR processing indexes every tx directly, while blocks processing indexes them via events, some txs may be indexed in both ways, which is a waste of disk storage