### PR TITLE
Fix of metrics flags

### DIFF
--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -151,6 +151,8 @@ func initFlags() {
 	metricsFlags = []cli.Flag{
 		utils.MetricsEnabledFlag,
 		utils.MetricsEnabledExpensiveFlag,
+		utils.MetricsHTTPFlag,
+		utils.MetricsPortFlag,
 		utils.MetricsEnableInfluxDBFlag,
 		utils.MetricsInfluxDBEndpointFlag,
 		utils.MetricsInfluxDBDatabaseFlag,


### PR DESCRIPTION
Metrics flags update according to new github.com/ethereum/go-ethereum version:

- --metrics.addr: defines the endpoint for a stand-alone metrics HTTP endpoint.
- --metrics.port: defines the port for a metrics HTTP endpoint (default 6060).
