### PR TITLE
Save snapsync journal during stopping

### DIFF
--- a/gossip/sync.go
+++ b/gossip/sync.go
@@ -283,6 +283,10 @@ func (h *handler) snapsyncStateLoop() {
 				cmd.snapsyncCancelCmd.done <- struct{}{}
 			}
 		case <-h.snapState.quit:
+			if h.snapState.cancel != nil {
+				_ = h.snapState.cancel()
+				h.snapState.cancel = nil
+			}
 			return
 		}
 	}


### PR DESCRIPTION
- Save snapsync journal during stopping. Since it's saved only after `snapState.cancel()`, previously it was saved only during a switch of an epoch