### PR TITLE
[Config] Don't overwrite default dataDir from config file

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -238,8 +238,6 @@ func setDataDir(ctx *cli.Context, cfg *node.Config) {
 			log.Crit("Invalid flag", "flag", FakeNetFlag.Name, "err", err)
 		}
 		cfg.DataDir = filepath.Join(defaultDataDir, fmt.Sprintf("fakenet-%d", num))
-	default:
-		cfg.DataDir = defaultDataDir
 	}
 }
 


### PR DESCRIPTION
Currently [Node] -> DataDir property specified in config TOML file gets overwritten when parsing command line parameters, even the command line parameter was not specified.

In case the commandline param is not given, the config already contains either the DataDir from TOML file or the default path.
There is no need to overwrite it in case the datadir commandline parameter is not given.

Steps for reproduction:
- Create a config.toml file containing:
```
[Node]
DataDir = "/tmp/test"
```
- launch opera --config config.toml dumpconfig