### PR TITLE
Fix panics on non-existing block RPC requests

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -998,7 +998,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	// Recap the highest gas limit with account's available balance.
 	if feeCap.BitLen() != 0 {
 		state, _, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-		if err != nil {
+		if state == nil || err != nil {
 			return 0, err
 		}
 		balance := state.GetBalance(*args.From) // from can't be nil
@@ -1547,7 +1547,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 	}
 	if tx != nil {
 		header, err := s.b.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber))
-		if err != nil {
+		if header == nil || err != nil {
 			return nil, err
 		}
 		return newRPCTransaction(tx, header.Hash, blockNumber, index, header.BaseFee), nil
@@ -1947,14 +1947,14 @@ func (api *PublicDebugAPI) SeedHash(ctx context.Context, number uint64) (string,
 func (api *PublicDebugAPI) BlocksTransactionTimes(ctx context.Context, untilBlock rpc.BlockNumber, maxBlocks hexutil.Uint64) (map[hexutil.Uint64]hexutil.Uint, error) {
 
 	until, err := api.b.HeaderByNumber(ctx, untilBlock)
-	if err != nil {
+	if until == nil || err != nil {
 		return nil, err
 	}
 	untilN := until.Number.Uint64()
 	times := map[hexutil.Uint64]hexutil.Uint{}
 	for i := untilN; i >= 1 && i+uint64(maxBlocks) > untilN; i-- {
 		b, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(i))
-		if err != nil {
+		if b == nil || err != nil {
 			return nil, err
 		}
 		if b.Transactions.Len() == 0 {

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -51,6 +51,7 @@ func (b *EthAPIBackend) CurrentBlock() *evmcore.EvmBlock {
 	return b.state.CurrentBlock()
 }
 
+// HeaderByNumber returns evm block header by its number, or nil if not exists.
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*evmcore.EvmHeader, error) {
 	blk, err := b.BlockByNumber(ctx, number)
 	if err != nil {
@@ -62,7 +63,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	return blk.Header(), err
 }
 
-// HeaderByHash returns evm header by its (atropos) hash.
+// HeaderByHash returns evm block header by its (atropos) hash, or nil if not exists.
 func (b *EthAPIBackend) HeaderByHash(ctx context.Context, h common.Hash) (*evmcore.EvmHeader, error) {
 	index := b.svc.store.GetBlockIndex(hash.Event(h))
 	if index == nil {
@@ -71,7 +72,7 @@ func (b *EthAPIBackend) HeaderByHash(ctx context.Context, h common.Hash) (*evmco
 	return b.HeaderByNumber(ctx, rpc.BlockNumber(*index))
 }
 
-// BlockByNumber returns block by its number.
+// BlockByNumber returns evm block by its number, or nil if not exists.
 func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*evmcore.EvmBlock, error) {
 	if number == rpc.PendingBlockNumber {
 		number = rpc.LatestBlockNumber
@@ -88,6 +89,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	return blk, nil
 }
 
+// StateAndHeaderByNumberOrHash returns evm state and block header by block number or block hash, err if not exists.
 func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *evmcore.EvmHeader, error) {
 	var header *evmcore.EvmHeader
 	if number, ok := blockNrOrHash.Number(); ok && (number == rpc.LatestBlockNumber || number == rpc.PendingBlockNumber) {


### PR DESCRIPTION
Fix conditions in ethapi to fix logged panics like this:

```
ERROR[02-21|13:22:13.963] RPC method eth_getTransactionByHash crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 211568 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
 	/home/opera/go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc1.0.20211223105936-3db2e88af263/rpc/service.go:200 +0x89
 panic({0x13d2760, 0x21cbe90})
 	/usr/local/go/src/runtime/panic.go:1038 +0x215
 github.com/Fantom-foundation/go-opera/ethapi.(*PublicTransactionPoolAPI).GetTransactionByHash(0xc00e050540, {0x18465f8, 0xc0155001c0}, {0x6c, 0x71, 0x94, 0x68, 0xfc, 0xf5, 0xd1, ...})
	/home/opera/go/src/pebble-go-opera/ethapi/api.go:1553 +0xcd
```