### PR TITLE
Port debug_trace* RPC methods from ethereum

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2178,7 +2178,8 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 	if threads > len(txs) {
 		threads = len(txs)
 	}
-	blockCtx := evmcore.NewEVMBlockContext(block.Header(), nil, nil)
+
+	blockCtx := api.b.GetBlockContext(block.Header())
 	blockHash := block.Hash
 	for th := 0; th < threads; th++ {
 		pend.Add(1)

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -73,6 +73,7 @@ type Backend interface {
 	GetReceiptsByNumber(ctx context.Context, number rpc.BlockNumber) (types.Receipts, error)
 	GetTd(hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg evmcore.Message, state *state.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config) (*vm.EVM, func() error, error)
+	GetBlockContext(header *evmcore.EvmHeader) vm.BlockContext
 	MinGasPrice() *big.Int
 	MaxGasLimit() uint64
 

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -309,6 +309,10 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, msg evmcore.Message, state *
 	return vm.NewEVM(context, txContext, state, config, *vmConfig), vmError, nil
 }
 
+func (b *EthAPIBackend) GetBlockContext(header *evmcore.EvmHeader) vm.BlockContext {
+	return evmcore.NewEVMBlockContext(header, b.state, nil)
+}
+
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	err := b.svc.txpool.AddLocal(signedTx)
 	if err == nil {


### PR DESCRIPTION
This PR ports following RPC methods from go-ethereum:

* debug_traceTransaction
* debug_traceBlockByHash
* debug_traceBlockByNumber

Example calls for testing on testnet (block 801883):
```
curl 'http://localhost:16761/' -X POST -H 'Content-Type: application/json' --data '{"id":1, "method":"debug_traceTransaction", "params": ["0x5a6fd9fa0113910a3c6bd1df558640f577ab38bf11477ffbe9786c94c498edf2", {}]}'
curl 'http://localhost:16761/' -X POST -H 'Content-Type: application/json' --data '{"id":1, "method":"debug_traceBlockByHash", "params": ["0x00000a9e00003862e522451bb81c611d606869163082c6f828b176359bc0b2e4", {}]}'
curl 'http://localhost:16761/' -X POST -H 'Content-Type: application/json' --data '{"id":1, "method":"debug_traceBlockByNumber", "params": ["0xC3C5B", {}]}'

```