### PR TITLE
Port debug_trace* RPC methods into release/txtracing/1.1.0-rc.4

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2178,7 +2178,8 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 	if threads > len(txs) {
 		threads = len(txs)
 	}
-	blockCtx := evmcore.NewEVMBlockContext(block.Header(), nil, nil)
+
+	blockCtx := api.b.GetBlockContext(block.Header())
 	blockHash := block.Hash
 	for th := 0; th < threads; th++ {
 		pend.Add(1)

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -74,6 +74,7 @@ type Backend interface {
 	GetReceiptsByNumber(ctx context.Context, number rpc.BlockNumber) (types.Receipts, error)
 	GetTd(hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg evmcore.Message, state *state.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config) (*vm.EVM, func() error, error)
+	GetBlockContext(header *evmcore.EvmHeader) vm.BlockContext
 	MinGasPrice() *big.Int
 	MaxGasLimit() uint64
 

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -333,6 +333,10 @@ func (b *EthAPIBackend) GetEVM(ctx context.Context, msg evmcore.Message, state *
 	return vm.NewEVM(context, txContext, state, config, *vmConfig), vmError, nil
 }
 
+func (b *EthAPIBackend) GetBlockContext(header *evmcore.EvmHeader) vm.BlockContext {
+	return evmcore.NewEVMBlockContext(header, b.state, nil)
+}
+
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	err := b.svc.txpool.AddLocal(signedTx)
 	if err == nil {


### PR DESCRIPTION
Fixed version of https://github.com/Fantom-foundation/go-opera/pull/263 - use `opera.DefaultVMConfig` even in debug

To be merged into release/txtracing/1.1.0-rc.4 by discussion with @quan8