### PR TITLE
Fix debug_traceBlock - prevent garbage collecting of EvmHeader ref

### DIFF
--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -48,7 +48,7 @@ func NewEVMBlockContext(header *EvmHeader, chain DummyChain, author *common.Addr
 	return vm.BlockContext{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
-		GetHash:     GetHashFn(header, chain),
+		GetHash:     GetHashFn(*header, chain),
 		Coinbase:    beneficiary,
 		BlockNumber: new(big.Int).Set(header.Number),
 		Time:        new(big.Int).SetUint64(uint64(header.Time.Unix())),
@@ -67,7 +67,7 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number
-func GetHashFn(ref *EvmHeader, chain DummyChain) func(n uint64) common.Hash {
+func GetHashFn(ref EvmHeader, chain DummyChain) func(n uint64) common.Hash {
 	// Cache will initially contain [refHash.parent],
 	// Then fill up with [refHash.p, refHash.pp, refHash.ppp, ...]
 	var cache []common.Hash


### PR DESCRIPTION
This fixes nil pointer panic which rarely occurs during `debug_traceBlockByHash` RPC requests.

The changes seems meaningless, but it prevents garbage collection of the EvmHeader and following panic when the returned function is called.

The issue decription:
* evmcore.NewEVMBlockContext() is called with not-nil EvmHeader pointer
* the function successfully access the EvmHeader.BaseFee at line 45
* the pointer is passed into evmcore.GetHashFn - which returns a function pointer
* when the function pointer is called later, it panics when trying to access the EvmHeader
This happens very rarely - once per several days on a server bombarded with bunch of debug_trace requests and it is not reproducible by repeating the same RPC request.

```
2022/04/07 23:25:59 opera err panic: runtime error: invalid memory address or nil pointer dereference
2022/04/07 23:25:59 opera err [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd8b526]
2022/04/07 23:25:59 opera err 
2022/04/07 23:25:59 opera err goroutine 59603186 [running]:
2022/04/07 23:25:59 opera err github.com/Fantom-foundation/go-opera/evmcore.GetHashFn.func1(0x19cf58d)
2022/04/07 23:25:59 opera err   /go/go-opera/evmcore/evm.go:78 +0x126
2022/04/07 23:25:59 opera err github.com/ethereum/go-ethereum/core/vm.opBlockhash(0x0, 0x0, 0x0)
2022/04/07 23:25:59 opera err   /go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc4/core/vm/instructions.go:448 +0xa6
```
(stacktrace relevant for revision e1cea271af2a83547dbcd245ca2ea83a8ff34c42)