### PR TITLE
Fix concurrent access to blockCtx in debug_traceBlock

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2179,12 +2179,14 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 		threads = len(txs)
 	}
 
-	blockCtx := api.b.GetBlockContext(block.Header())
+	blockHeader := block.Header()
 	blockHash := block.Hash
 	for th := 0; th < threads; th++ {
 		pend.Add(1)
 		go func() {
 			defer pend.Done()
+			blockCtx := api.b.GetBlockContext(blockHeader)
+
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				msg, _ := txs[task.index].AsMessage(signer, block.BaseFee)
@@ -2203,6 +2205,7 @@ func (api *PublicDebugAPI) traceBlock(ctx context.Context, block *evmcore.EvmBlo
 		}()
 	}
 	// Feed the transactions into the tracers and return
+	blockCtx := api.b.GetBlockContext(blockHeader)
 	var failed error
 	for i, tx := range txs {
 		// Send the trace task over for execution

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -48,7 +48,7 @@ func NewEVMBlockContext(header *EvmHeader, chain DummyChain, author *common.Addr
 	return vm.BlockContext{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
-		GetHash:     GetHashFn(*header, chain),
+		GetHash:     GetHashFn(header, chain),
 		Coinbase:    beneficiary,
 		BlockNumber: new(big.Int).Set(header.Number),
 		Time:        new(big.Int).SetUint64(uint64(header.Time.Unix())),
@@ -67,7 +67,7 @@ func NewEVMTxContext(msg Message) vm.TxContext {
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number
-func GetHashFn(ref EvmHeader, chain DummyChain) func(n uint64) common.Hash {
+func GetHashFn(ref *EvmHeader, chain DummyChain) func(n uint64) common.Hash {
 	// Cache will initially contain [refHash.parent],
 	// Then fill up with [refHash.p, refHash.pp, refHash.ppp, ...]
 	var cache []common.Hash


### PR DESCRIPTION
Fix nil panics caused by concurrent access to blockCtx (and GetHashFn function in it).

This is related to following panics:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd8b626]

goroutine 212151913 [running]:
github.com/Fantom-foundation/go-opera/evmcore.GetHashFn.func1(0x1adf0d9)
	/go/go-opera/evmcore/evm.go:78 +0x126
github.com/ethereum/go-ethereum/core/vm.opBlockhash(0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc4/core/vm/instructions.go:448 +0xa6
github.com/ethereum/go-ethereum/core/vm.(*EVMInterpreter).Run(0xc01201e000, 0xc051d3fa40, {0xc04a20a3c0, 0x44, 0x44}, 0x0)
	/go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc4/core/vm/interpreter.go:263 +0xac4
github.com/ethereum/go-ethereum/core/vm.(*EVM).Call(0xc08885ea80, {0x157c340, 0xc0aed6a930}, {0x24, 0x1, 0x7c, 0x94, 0x10, 0x8c, 0xef, ...}, ...)
	/go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc4/core/vm/evm.go:237 +0xceb
github.com/Fantom-foundation/go-opera/evmcore.(*StateTransition).TransitionDb(0xc0753cb730)
	/go/go-opera/evmcore/state_transition.go:292 +0x58e
github.com/Fantom-foundation/go-opera/evmcore.ApplyMessage(0xc07401b440, {0x15b3da0, 0xc07401b440}, 0x0)
	/go/go-opera/evmcore/state_transition.go:173 +0x32
github.com/Fantom-foundation/go-opera/ethapi.(*PublicDebugAPI).traceTx(0xc03c3fa010, {0x159a998, 0xc0a0c99680}, {0x15b3da0, 0xc07401b440}, 0xc00c529df8, {0x1429ba0, 0x1429ba8, 0xc06d497e00, {0x0, ...}, ...}, ...)
	/go/go-opera/ethapi/api.go:2070 +0x5a9
github.com/Fantom-foundation/go-opera/ethapi.(*PublicDebugAPI).traceBlock.func1()
	/go/go-opera/ethapi/api.go:2196 +0x406
created by github.com/Fantom-foundation/go-opera/ethapi.(*PublicDebugAPI).traceBlock
	/go/go-opera/ethapi/api.go:2186 +0x2c5
```