### PR TITLE
Upgrade "Emitting is paused" logs to Warn level

### DIFF
--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -71,9 +71,9 @@ func (em *Emitter) logSyncStatus(wait time.Duration, syncErr error) bool {
 	}
 
 	if wait == 0 {
-		em.Periodic.Info(7*time.Second, "Emitting is paused", "reason", syncErr)
+		em.Periodic.Warn(7*time.Second, "Emitting is paused", "reason", syncErr)
 	} else {
-		em.Periodic.Info(7*time.Second, "Emitting is paused", "reason", syncErr, "wait", wait)
+		em.Periodic.Warn(7*time.Second, "Emitting is paused", "reason", syncErr, "wait", wait)
 	}
 	return false
 }


### PR DESCRIPTION
For Validators, emission pause logs are very important. Currently they're INFO-level; however, there's no reason to keep INFO-level messages on a properly-running node. The log files get unwieldy pretty fast.

While there are certainly options to manage this, such as logrotate, I believe updating this Validator message to WARN would allow Validators to set a proper `--verbosity` level, but more importantly reflect their actual importance.