### PR TITLE
Change in tx trace address creation after revert

### DIFF
--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -108,7 +108,7 @@ func stackPosFromEnd(stackData []uint256.Int, pos int) *big.Int {
 func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, rData []byte, depth int, err error) {
 
 	// When going back from inner call
-	if lastState(tr.state).level == depth {
+	for lastState(tr.state).level >= depth {
 		result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
 		if lastState(tr.state).create && result != nil {
 			if len(scope.Stack.Data()) > 0 {
@@ -120,6 +120,9 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 		tr.traceAddress = removeTraceAddressLevel(tr.traceAddress, depth)
 		tr.state = tr.state[:len(tr.state)-1]
 		tr.rootTrace.Stack = tr.rootTrace.Stack[:len(tr.rootTrace.Stack)-1]
+		if lastState(tr.state).level == depth {
+			break
+		}
 	}
 
 	// Match processed instruction and create trace based on it
@@ -188,7 +191,7 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 		tr.state = append(tr.state, depthState{depth, false})
 
 	case vm.RETURN, vm.STOP:
-		if !tr.reverted {
+		if tr != nil {
 			result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
 			if result != nil {
 				var data []byte
@@ -250,7 +253,8 @@ func (tr *TraceStructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Du
 	tr.output = output
 }
 
-func (*TraceStructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {}
+func (*TraceStructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+}
 
 func (*TraceStructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 


### PR DESCRIPTION
Change of transaction address creation after revert happens in the evm processing.
Fix is for https://github.com/Fantom-foundation/go-opera/issues/288 and for this case:
`curl --data '{"method":"trace_transaction","params":["0xe6a794efb19a80d5f4725e27b136d57218a9708fc1f968a4d11ff6836d0e5b29"],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST https://rpcapi-tracing.fantom.network/
If you take a look at the last action:
 "subtraces": 0,
      "traceAddress": [
        5,
        2,
        0,
        6,
        0
      ]
You will find it has traceAddress start with
5
 , but we can't trace back cause there's no
[5], [5,2] ...
in json string.`