### PR TITLE
Added abillity to export, import and delete transaction traces from db

### DIFF
--- a/cmd/opera/launcher/chaincmd.go
+++ b/cmd/opera/launcher/chaincmd.go
@@ -49,6 +49,21 @@ Events are fully verified by default, unless overridden by --check=false flag.`,
 
 The import command imports EVM storage (trie nodes, code, preimages) from files.`,
 			},
+			{
+				Name:      "txtraces",
+				Usage:     "Import transaction traces",
+				ArgsUsage: "<filename>",
+				Action:    utils.MigrateFlags(importTxTraces),
+				Flags: []cli.Flag{
+					DataDirFlag,
+				},
+				Description: `
+    opera import txtraces
+
+The import command imports transaction traces and replaces the old ones 
+with traces from a file.
+`,
+			},
 		},
 	}
 	exportCommand = cli.Command{
@@ -71,6 +86,47 @@ The import command imports EVM storage (trie nodes, code, preimages) from files.
 Requires a first argument of the file to write to.
 Optional second and third arguments control the first and
 last epoch to write. If the file ends with .gz, the output will
+be gzipped
+`,
+			},
+			{
+				Name:      "txtraces",
+				Usage:     "Export stored transaction traces",
+				ArgsUsage: "<filename> [<blockFrom> <blockTo>]",
+				Action:    utils.MigrateFlags(exportTxTraces),
+				Flags: []cli.Flag{
+					DataDirFlag,
+				},
+				Description: `
+    opera export txtraces
+
+Requires a first argument of the file to write to.
+Optional second and third arguments control the first and
+last block to write transaction traces. If the file ends with .gz, the output will
+be gzipped
+`,
+			},
+		},
+	}
+	deleteCommand = cli.Command{
+		Name:     "delete",
+		Usage:    "Delete blockchain data",
+		Category: "MISCELLANEOUS COMMANDS",
+
+		Subcommands: []cli.Command{
+			{
+				Name:      "txtraces",
+				Usage:     "Delete transaction traces",
+				ArgsUsage: "[<blockFrom> <blockTo>]",
+				Action:    utils.MigrateFlags(deleteTxTraces),
+				Flags: []cli.Flag{
+					DataDirFlag,
+				},
+				Description: `
+    opera delete txtraces
+
+Optional first and second arguments control the first and
+last block to delete transaction traces from. If the file ends with .gz, the output will
 be gzipped
 `,
 			},

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -211,6 +211,7 @@ func init() {
 		importCommand,
 		exportCommand,
 		checkCommand,
+		deleteCommand,
 		// See snapshot.go
 		snapshotCommand,
 	}

--- a/cmd/opera/launcher/txtracingcmd.go
+++ b/cmd/opera/launcher/txtracingcmd.go
@@ -1,0 +1,268 @@
+package launcher
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/Fantom-foundation/go-opera/gossip"
+	"github.com/Fantom-foundation/go-opera/integration"
+	"github.com/Fantom-foundation/go-opera/inter"
+)
+
+type TracePayload struct {
+	Key    common.Hash
+	Traces []byte
+}
+
+// importTxTraces imports transaction traces from a specified file
+func importTxTraces(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	// Watch for Ctrl-C while the import is running.
+	// If a signal is received, the import will stop.
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
+
+	cfg := makeAllConfigs(ctx)
+
+	rawProducer := integration.DBProducer(path.Join(cfg.Node.DataDir, "chaindata"), cfg.cachescale)
+	gdb, err := makeRawGossipStoreTrace(rawProducer, cfg)
+	if err != nil {
+		log.Crit("DB opening error", "datadir", cfg.Node.DataDir, "err", err)
+	}
+	defer gdb.Close()
+
+	fn := ctx.Args().First()
+
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var (
+		reader  io.Reader = fh
+		counter int
+	)
+	if strings.HasSuffix(fn, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return err
+		}
+		defer reader.(*gzip.Reader).Close()
+	}
+
+	log.Info("Importing transaction traces from file", "file", fn)
+	start, reported := time.Now(), time.Now()
+
+	stream := rlp.NewStream(reader, 0)
+	for {
+		select {
+		case <-interrupt:
+			return fmt.Errorf("interrupted")
+		default:
+		}
+		e := new(TracePayload)
+		err = stream.Decode(e)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		} else {
+			gdb.TxTraceStore().SetTxTrace(e.Key, e.Traces)
+			counter++
+			if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+				log.Info("Importing transaction traces", "imported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+				reported = time.Now()
+			}
+		}
+	}
+	log.Info("Imported transaction traces", "imported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+
+	return nil
+}
+
+// deleteTxTraces removes transaction traces for specified block range
+func deleteTxTraces(ctx *cli.Context) error {
+
+	cfg := makeAllConfigs(ctx)
+
+	rawProducer := integration.DBProducer(path.Join(cfg.Node.DataDir, "chaindata"), cfg.cachescale)
+	gdb, err := makeRawGossipStoreTrace(rawProducer, cfg)
+	if err != nil {
+		log.Crit("DB opening error", "datadir", cfg.Node.DataDir, "err", err)
+	}
+	defer gdb.Close()
+
+	from := idx.Block(1)
+	if len(ctx.Args()) > 0 {
+		n, err := strconv.ParseUint(ctx.Args().Get(1), 10, 64)
+		if err != nil {
+			return err
+		}
+		from = idx.Block(n)
+	}
+	to := gdb.GetLatestBlockIndex()
+	if len(ctx.Args()) > 1 {
+		n, err := strconv.ParseUint(ctx.Args().Get(2), 10, 64)
+		if err != nil {
+			return err
+		}
+		to = idx.Block(n)
+	}
+
+	log.Info("Deleting transaction traces", "from block", from, "to block", to)
+
+	err = deleteTraces(gdb, from, to)
+	if err != nil {
+		utils.Fatalf("Deleting traces error: %v\n", err)
+	}
+
+	return nil
+}
+
+// exportTxTraces exports transaction traces from specified block range
+func exportTxTraces(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 {
+		utils.Fatalf("This command requires an argument.")
+	}
+
+	cfg := makeAllConfigs(ctx)
+
+	rawProducer := integration.DBProducer(path.Join(cfg.Node.DataDir, "chaindata"), cfg.cachescale)
+	gdb, err := makeRawGossipStoreTrace(rawProducer, cfg)
+	if err != nil {
+		log.Crit("DB opening error", "datadir", cfg.Node.DataDir, "err", err)
+	}
+	defer gdb.Close()
+
+	fn := ctx.Args().First()
+
+	// Open the file handle and potentially wrap with a gzip stream
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+
+	var writer io.Writer = fh
+	if strings.HasSuffix(fn, ".gz") {
+		writer = gzip.NewWriter(writer)
+		defer writer.(*gzip.Writer).Close()
+	}
+
+	from := idx.Block(1)
+	if len(ctx.Args()) > 1 {
+		n, err := strconv.ParseUint(ctx.Args().Get(1), 10, 64)
+		if err != nil {
+			return err
+		}
+		from = idx.Block(n)
+	}
+	to := gdb.GetLatestBlockIndex()
+	if len(ctx.Args()) > 2 {
+		n, err := strconv.ParseUint(ctx.Args().Get(2), 10, 64)
+		if err != nil {
+			return err
+		}
+		to = idx.Block(n)
+	}
+
+	log.Info("Exporting transaction traces to file", "file", fn)
+
+	err = exportTraceTo(writer, gdb, from, to)
+	if err != nil {
+		utils.Fatalf("Export error: %v\n", err)
+	}
+
+	return nil
+}
+
+func makeRawGossipStoreTrace(rawProducer kvdb.IterableDBProducer, cfg *config) (*gossip.Store, error) {
+	if err := checkStateInitialized(rawProducer); err != nil {
+		return nil, err
+	}
+	dbs := &integration.DummyFlushableProducer{rawProducer}
+	gdb := gossip.NewStore(dbs, cfg.OperaStore)
+
+	if gdb.TxTraceStore() == nil {
+		return nil, errors.New("transaction traces db store is not initialized")
+	}
+
+	return gdb, nil
+}
+
+// exportTraceTo writer the active chain.
+func exportTraceTo(w io.Writer, gdb *gossip.Store, from, to idx.Block) (err error) {
+	start, reported := time.Now(), time.Now()
+
+	var (
+		counter int
+		block   *inter.Block
+	)
+
+	for i := from; i <= to; i++ {
+		block = gdb.GetBlock(i)
+		for _, tx := range gdb.GetBlockTxs(i, block) {
+			traces := gdb.TxTraceStore().GetTx(tx.Hash())
+			if len(traces) > 0 {
+				counter++
+				rlp.Encode(w, TracePayload{tx.Hash(), traces})
+			}
+			if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+				log.Info("Exporting transaction traces", "at block", i, "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+				reported = time.Now()
+			}
+		}
+	}
+	log.Info("Exported transaction traces", "from block", from, "to block", to, "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+
+	return
+}
+
+// deleteTraces removes transaction traces for specified block range
+func deleteTraces(gdb *gossip.Store, from, to idx.Block) (err error) {
+	start, reported := time.Now(), time.Now()
+
+	var (
+		counter int
+	)
+
+	for i := from; i <= to; i++ {
+		for _, tx := range gdb.GetBlockTxs(i, gdb.GetBlock(i)) {
+			ok, err := gdb.TxTraceStore().HasTxTrace(tx.Hash())
+			fmt.Println("jd", tx.Hash(), ok, err)
+			if ok && err == nil {
+				counter++
+				gdb.TxTraceStore().RemoveTxTrace(tx.Hash())
+				if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+					log.Info("Deleting traces", "deleted", counter, "elapsed", common.PrettyDuration(time.Since(start)))
+					reported = time.Now()
+				}
+			}
+		}
+	}
+	log.Info("Deleting transaction traces done", "deleted", counter, "from block", from, "to block", to, "elapsed", common.PrettyDuration(time.Since(start)))
+	return
+}

--- a/cmd/opera/launcher/txtracingcmd.go
+++ b/cmd/opera/launcher/txtracingcmd.go
@@ -92,7 +92,7 @@ func importTxTraces(ctx *cli.Context) error {
 		} else {
 			gdb.TxTraceStore().SetTxTrace(e.Key, e.Traces)
 			counter++
-			if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+			if time.Since(reported) >= statsReportLimit {
 				log.Info("Importing transaction traces", "imported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
 				reported = time.Now()
 			}
@@ -235,7 +235,7 @@ func exportTraceTo(w io.Writer, gdb *gossip.Store, from, to idx.Block) (err erro
 				counter++
 				rlp.Encode(w, TracePayload{tx.Hash(), traces})
 			}
-			if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+			if time.Since(reported) >= statsReportLimit {
 				log.Info("Exporting transaction traces", "at block", i, "exported", counter, "elapsed", common.PrettyDuration(time.Since(start)))
 				reported = time.Now()
 			}
@@ -282,7 +282,7 @@ func deleteTraces(gdb *gossip.Store, from, to idx.Block) (err error) {
 			if ok && err == nil {
 				counter++
 				gdb.TxTraceStore().RemoveTxTrace(tx.Hash())
-				if counter%100 == 1 && time.Since(reported) >= statsReportLimit {
+				if time.Since(reported) >= statsReportLimit {
 					log.Info("Deleting traces", "deleted", counter, "elapsed", common.PrettyDuration(time.Since(start)))
 					reported = time.Now()
 				}

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -230,6 +230,10 @@ func (s *Store) EvmStore() *evmstore.Store {
 	return s.evm
 }
 
+func (s *Store) TxTraceStore() *txtrace.Store {
+	return s.txtrace
+}
+
 func (s *Store) CaptureEvmKvdbSnapshot() {
 	if s.evm.Snaps == nil {
 		return

--- a/gossip/txtrace/store.go
+++ b/gossip/txtrace/store.go
@@ -44,3 +44,13 @@ func (s *Store) GetTx(txID common.Hash) []byte {
 	}
 	return buf
 }
+
+// RemoveTxTrace removes key and []byte representation of transaction traces.
+func (s *Store) RemoveTxTrace(txID common.Hash) error {
+	return s.mainDB.Delete(txID.Bytes())
+}
+
+// HasTxTrace stores []byte representation of transaction traces.
+func (s *Store) HasTxTrace(txID common.Hash) (bool, error) {
+	return s.mainDB.Has(txID.Bytes())
+}

--- a/gossip/txtrace/store.go
+++ b/gossip/txtrace/store.go
@@ -54,3 +54,14 @@ func (s *Store) RemoveTxTrace(txID common.Hash) error {
 func (s *Store) HasTxTrace(txID common.Hash) (bool, error) {
 	return s.mainDB.Has(txID.Bytes())
 }
+
+// ForEachTxtrace returns iterator for all transaction traces in db
+func (s *Store) ForEachTxtrace(onEvent func(key common.Hash, traces []byte) bool) {
+	it := s.mainDB.NewIterator(nil, nil)
+	defer it.Release()
+	for it.Next() {
+		if !onEvent(common.BytesToHash(it.Key()), it.Value()) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
Added abillity to export, import and delete transaction traces from db.
Used as a command for the stoped node to be able to migrate transaction traces.