### PR TITLE
Suppress errSnapWithoutOpera log

### DIFF
--- a/gossip/handler_snap.go
+++ b/gossip/handler_snap.go
@@ -58,7 +58,11 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 	h.peerWG.Add(1)
 	defer h.peerWG.Done()
 	if err := h.peers.RegisterSnapExtension(peer); err != nil {
-		peer.Log().Error("Snapshot extension registration failed", "err", err)
+		logger := peer.Log().Error
+		if err == errSnapWithoutOpera {
+			logger = peer.Log().Trace
+		}
+		logger("Snapshot extension registration failed", "err", err)
 		return err
 	}
 	return handler(peer)

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -25,9 +25,7 @@ import (
 )
 
 var (
-	errClosed            = errors.New("peer set is closed")
-	errAlreadyRegistered = errors.New("peer is already registered")
-	errNotRegistered     = errors.New("peer is not registered")
+	errNotRegistered = errors.New("peer is not registered")
 )
 
 const (


### PR DESCRIPTION
- Suppress verbosity of errSnapWithoutOpera, as It is typically fired when connecting to a renamed fork of go-opera. FIx 