### PR TITLE
Rework exitwhensynced functionality

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -98,6 +98,14 @@ var (
 		Usage: `Blockchain sync mode ("full" or "snap")`,
 		Value: "full",
 	}
+	ExitWhenAgeFlag = cli.DurationFlag{
+		Name:  "exitwhensynced.age",
+		Usage: "Exits after synchronisation reaches the required age",
+	}
+	ExitWhenEpochFlag = cli.Uint64Flag{
+		Name:  "exitwhensynced.epoch",
+		Usage: "Exits after synchronisation reaches the required epoch",
+	}
 )
 
 type GenesisTemplate struct {

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -237,6 +237,11 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	}
 
 	s.mayCommit(newEpoch != oldEpoch)
+
+	if s.haltCheck != nil && s.haltCheck(oldEpoch, newEpoch, e.MedianTime().Time()) {
+		// halt syncing
+		s.stopped = true
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add `--exitwhensynced.age` and `--exitwhensynced.epoch` flags instead of `--exitwhensynced` flag:
- `--exitwhensynced.age` may be used instead of `--exitwhensynced` to stop node once it syncs up to a relatively latest state. `--exitwhensynced.age` requires to specify an exact age threshold of what's considered a latest state (e.g. 5s)
- `--exitwhensynced.epoch` allows to stop node exactly when it reaches a certain epoch. Its intended usecase is genesis files generation for a certain epoch