### PR TITLE
Rework version watcher

### DIFF
--- a/gossip/blockproc/verwatcher/config.go
+++ b/gossip/blockproc/verwatcher/config.go
@@ -1,8 +1,0 @@
-package verwatcher
-
-import "time"
-
-type Config struct {
-	ShutDownIfNotUpgraded     bool
-	WarningIfNotUpgradedEvery time.Duration
-}

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -11,12 +11,10 @@ import (
 	"github.com/Fantom-foundation/go-opera/logger"
 	"github.com/Fantom-foundation/go-opera/opera/contracts/driver"
 	"github.com/Fantom-foundation/go-opera/opera/contracts/driver/driverpos"
-	"github.com/Fantom-foundation/go-opera/utils/errlock"
 	"github.com/Fantom-foundation/go-opera/version"
 )
 
 type VerWarcher struct {
-	cfg   Config
 	store *Store
 
 	done chan struct{}
@@ -24,13 +22,23 @@ type VerWarcher struct {
 	logger.Instance
 }
 
-func New(cfg Config, store *Store) *VerWarcher {
+func New(store *Store) *VerWarcher {
 	return &VerWarcher{
-		cfg:      cfg,
 		store:    store,
 		done:     make(chan struct{}),
 		Instance: logger.New(),
 	}
+}
+
+func (w *VerWarcher) Pause() error {
+	if w.store.GetNetworkVersion() > version.AsU64() {
+		return fmt.Errorf("Network upgrade %s was activated. Current node version is %s. "+
+			"Please upgrade your node to continue syncing.", version.U64ToString(w.store.GetNetworkVersion()), version.AsString())
+	} else if w.store.GetMissedVersion() > 0 {
+		return fmt.Errorf("Node's state is dirty because node was upgraded after the network upgrade %s was activated. "+
+			"Please re-sync the chain data to continue.", version.U64ToString(w.store.GetMissedVersion()))
+	}
+	return nil
 }
 
 func (w *VerWarcher) OnNewLog(l *types.Log) {
@@ -40,42 +48,22 @@ func (w *VerWarcher) OnNewLog(l *types.Log) {
 	if l.Topics[0] == driverpos.Topics.UpdateNetworkVersion && len(l.Data) >= 32 {
 		netVersion := new(big.Int).SetBytes(l.Data[24:32]).Uint64()
 		w.store.SetNetworkVersion(netVersion)
-		if netVersion > version.AsU64() {
-			if w.cfg.ShutDownIfNotUpgraded {
-				errlock.Permanent(fmt.Errorf("The network's supported version of %s was activated at block %d.\n"+
-					"Node's current version is %s and a shutdown is required as ShutDownIfNotUpgraded flag was set.\n"+
-					"Please upgrade the node to continue.", version.U64ToString(netVersion), l.BlockNumber, version.AsString()))
-				panic("unreachable")
-			} else if w.store.GetMissedVersion() == 0 {
-				w.store.SetMissedVersion(netVersion)
-			}
-		}
 		w.log()
 	}
 }
 
 func (w *VerWarcher) log() {
-	if w.cfg.WarningIfNotUpgradedEvery == 0 {
-		return
-	}
-	if w.store.GetNetworkVersion() > version.AsU64() {
-		w.Log.Warn(fmt.Sprintf("Network upgrade %s was activated. Current node version is %s. "+
-			"Please upgrade your node and re-sync the chain data.", version.U64ToString(w.store.GetNetworkVersion()), version.AsString()))
-	} else if w.store.GetMissedVersion() > 0 {
-		w.Log.Warn(fmt.Sprintf("Node's state is dirty because node was upgraded after the network upgrade %s was activated. "+
-			"Please re-sync the chain data to continue.", version.U64ToString(w.store.GetMissedVersion())))
+	if err := w.Pause(); err != nil {
+		w.Log.Warn(err.Error())
 	}
 }
 
 func (w *VerWarcher) Start() {
-	if w.cfg.WarningIfNotUpgradedEvery == 0 {
-		return
-	}
 	w.log()
 	w.wg.Add(1)
 	go func() {
 		defer w.wg.Done()
-		ticker := time.NewTicker(w.cfg.WarningIfNotUpgradedEvery)
+		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 		for {
 			select {

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -174,6 +174,9 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	if s.stopped {
 		return errStopped
 	}
+	if err := s.verWatcher.Pause(); err != nil {
+		return err
+	}
 	if gen, err := s.store.evm.Snaps.Generating(); gen || err != nil {
 		// never allow fullsync while EVM snap is still generating, as it may lead to a race condition
 		s.Log.Warn("EVM snapshot is not ready during event processing", "gen", gen, "err", err)

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/go-opera/eventcheck/heavycheck"
-	"github.com/Fantom-foundation/go-opera/gossip/blockproc/verwatcher"
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/gossip/filters"
 	"github.com/Fantom-foundation/go-opera/gossip/gasprice"
@@ -90,8 +89,6 @@ type (
 
 		// Gas Price Oracle options
 		GPO gasprice.Config
-
-		VersionWatcher verwatcher.Config
 
 		// RPCGasCap is the global gas cap for eth-call variants.
 		RPCGasCap uint64 `toml:",omitempty"`
@@ -210,10 +207,6 @@ func DefaultConfig(scale cachescale.Func) Config {
 			GasPowerWallRatio:           big.NewInt(0.05 * gasprice.DecimalUnit),
 		},
 
-		VersionWatcher: verwatcher.Config{
-			ShutDownIfNotUpgraded:     false,
-			WarningIfNotUpgradedEvery: 5 * time.Second,
-		},
 		RPCBlockExt: true,
 
 		RPCGasCap:   50000000,

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -261,7 +261,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{config.ExtRPCEnabled, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
 
-	svc.verWatcher = verwatcher.New(config.VersionWatcher, verwatcher.NewStore(store.table.NetworkVersion))
+	svc.verWatcher = verwatcher.New(verwatcher.NewStore(store.table.NetworkVersion))
 	svc.tflusher = svc.makePeriodicFlusher()
 
 	return svc, nil


### PR DESCRIPTION
- version watches prevents node from processing new events if an upgrade was missed, and removes 2 options of either only logging about a missed upgrade activation (default) or halting the node on a missed upgrade activation (had to be explicitly enabled). This is to prevent situation when node needs to be resynced if an upgrade activation was missed and node halting on missed upgrade activation wasn't explicitly enabled