### PR TITLE
Extend Opera-specific API calls

### DIFF
--- a/ethapi/abft_api.go
+++ b/ethapi/abft_api.go
@@ -20,7 +20,7 @@ func NewPublicAbftAPI(b Backend) *PublicAbftAPI {
 }
 
 func (s *PublicAbftAPI) GetValidators(ctx context.Context, epoch rpc.BlockNumber) (map[hexutil.Uint64]interface{}, error) {
-	_, es, err := s.b.GetEpochBlockState(ctx, epoch)
+	bs, es, err := s.b.GetEpochBlockState(ctx, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -29,9 +29,13 @@ func (s *PublicAbftAPI) GetValidators(ctx context.Context, epoch rpc.BlockNumber
 	}
 	res := map[hexutil.Uint64]interface{}{}
 	for _, vid := range es.Validators.IDs() {
+		profiles := es.ValidatorProfiles
+		if epoch == rpc.PendingBlockNumber {
+			profiles = bs.NextValidatorProfiles
+		}
 		res[hexutil.Uint64(vid)] = map[string]interface{}{
-			"weight": (*hexutil.Big)(es.ValidatorProfiles[vid].Weight),
-			"pubkey": es.ValidatorProfiles[vid].PubKey.String(),
+			"weight": (*hexutil.Big)(profiles[vid].Weight),
+			"pubkey": profiles[vid].PubKey.String(),
 		}
 	}
 	return res, nil

--- a/ethapi/abft_api.go
+++ b/ethapi/abft_api.go
@@ -20,7 +20,7 @@ func NewPublicAbftAPI(b Backend) *PublicAbftAPI {
 }
 
 func (s *PublicAbftAPI) GetValidators(ctx context.Context, epoch rpc.BlockNumber) (map[hexutil.Uint64]interface{}, error) {
-	es, err := s.b.GetEpochState(ctx, epoch)
+	_, es, err := s.b.GetEpochBlockState(ctx, epoch)
 	if err != nil {
 		return nil, err
 	}

--- a/ethapi/abft_api.go
+++ b/ethapi/abft_api.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // PublicAbftAPI provides an API to access consensus related information.
@@ -16,6 +17,24 @@ type PublicAbftAPI struct {
 // NewPublicAbftAPI creates a new SFC protocol API.
 func NewPublicAbftAPI(b Backend) *PublicAbftAPI {
 	return &PublicAbftAPI{b}
+}
+
+func (s *PublicAbftAPI) GetValidators(ctx context.Context, epoch rpc.BlockNumber) (map[hexutil.Uint64]interface{}, error) {
+	es, err := s.b.GetEpochState(ctx, epoch)
+	if err != nil {
+		return nil, err
+	}
+	if es == nil {
+		return nil, nil
+	}
+	res := map[hexutil.Uint64]interface{}{}
+	for _, vid := range es.Validators.IDs() {
+		res[hexutil.Uint64(vid)] = map[string]interface{}{
+			"weight": (*hexutil.Big)(es.ValidatorProfiles[vid].Weight),
+			"pubkey": es.ValidatorProfiles[vid].PubKey.String(),
+		}
+	}
+	return res, nil
 }
 
 // GetDowntime returns validator's downtime.

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -678,6 +679,18 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 // CurrentEpoch returns current epoch number.
 func (s *PublicBlockChainAPI) CurrentEpoch(ctx context.Context) hexutil.Uint64 {
 	return hexutil.Uint64(s.b.CurrentEpoch(ctx))
+}
+
+// GetRules returns network rules for an epoch
+func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumber) (interface{}, error) {
+	es, err := s.b.GetEpochState(ctx, epoch)
+	if err != nil {
+		return nil, err
+	}
+	if es == nil {
+		return nil, nil
+	}
+	return es.Rules, nil
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1260,6 +1260,7 @@ type extBlockApi struct {
 func RPCMarshalHeader(head *evmcore.EvmHeader, ext extBlockApi) map[string]interface{} {
 	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
+		"epoch":            hexutil.Uint64(hash.Event(head.Hash).Epoch()),
 		"hash":             head.Hash, // store EvmBlock's hash in extra, because extra is always empty
 		"parentHash":       head.ParentHash,
 		"nonce":            types.BlockNonce{},

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -683,7 +683,7 @@ func (s *PublicBlockChainAPI) CurrentEpoch(ctx context.Context) hexutil.Uint64 {
 
 // GetRules returns network rules for an epoch
 func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumber) (interface{}, error) {
-	es, err := s.b.GetEpochState(ctx, epoch)
+	_, es, err := s.b.GetEpochBlockState(ctx, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -691,6 +691,18 @@ func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumbe
 		return nil, nil
 	}
 	return es.Rules, nil
+}
+
+// GetEpochBlock returns block height in a beginning of an epoch
+func (s *PublicBlockChainAPI) GetEpochBlock(ctx context.Context, epoch rpc.BlockNumber) (hexutil.Uint64, error) {
+	bs, _, err := s.b.GetEpochBlockState(ctx, epoch)
+	if err != nil {
+		return 0, err
+	}
+	if bs == nil {
+		return 0, nil
+	}
+	return hexutil.Uint64(bs.LastBlock.Idx), nil
 }
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -682,7 +682,7 @@ func (s *PublicBlockChainAPI) CurrentEpoch(ctx context.Context) hexutil.Uint64 {
 }
 
 // GetRules returns network rules for an epoch
-func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumber) (interface{}, error) {
+func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumber) (*opera.Rules, error) {
 	_, es, err := s.b.GetEpochBlockState(ctx, epoch)
 	if err != nil {
 		return nil, err
@@ -690,7 +690,7 @@ func (s *PublicBlockChainAPI) GetRules(ctx context.Context, epoch rpc.BlockNumbe
 	if es == nil {
 		return nil, nil
 	}
-	return es.Rules, nil
+	return &es.Rules, nil
 }
 
 // GetEpochBlock returns block height in a beginning of an epoch

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/inter"
+	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 )
 
 // PeerProgress is synchronization status of a peer
@@ -96,6 +97,7 @@ type Backend interface {
 	SealedEpochTiming(ctx context.Context) (start inter.Timestamp, end inter.Timestamp)
 
 	// Lachesis aBFT API
+	GetEpochState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.EpochState, error)
 	GetDowntime(ctx context.Context, vid idx.ValidatorID) (idx.Block, inter.Timestamp, error)
 	GetUptime(ctx context.Context, vid idx.ValidatorID) (*big.Int, error)
 	GetOriginatedFee(ctx context.Context, vid idx.ValidatorID) (*big.Int, error)

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -97,7 +97,7 @@ type Backend interface {
 	SealedEpochTiming(ctx context.Context) (start inter.Timestamp, end inter.Timestamp)
 
 	// Lachesis aBFT API
-	GetEpochState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.EpochState, error)
+	GetEpochBlockState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.BlockState, *iblockproc.EpochState, error)
 	GetDowntime(ctx context.Context, vid idx.ValidatorID) (idx.Block, inter.Timestamp, error)
 	GetUptime(ctx context.Context, vid idx.ValidatorID) (*big.Int, error)
 	GetOriginatedFee(ctx context.Context, vid idx.ValidatorID) (*big.Int, error)

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/inter"
+	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/topicsdb"
 	"github.com/Fantom-foundation/go-opera/tracing"
@@ -504,6 +505,16 @@ func (b *EthAPIBackend) GetDowntime(ctx context.Context, vid idx.ValidatorID) (i
 		return 0, 0, nil
 	}
 	return missedBlocks, missedTime, nil
+}
+
+func (b *EthAPIBackend) GetEpochState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.EpochState, error) {
+	if epoch == rpc.PendingBlockNumber {
+		return nil, errors.New("pending epoch request isn't allowed")
+	}
+	if epoch == rpc.LatestBlockNumber {
+		epoch = rpc.BlockNumber(b.svc.store.GetEpoch())
+	}
+	return b.svc.store.GetHistoryEpochState(idx.Epoch(epoch)), nil
 }
 
 func (b *EthAPIBackend) CalcBlockExtApi() bool {

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -507,14 +507,16 @@ func (b *EthAPIBackend) GetDowntime(ctx context.Context, vid idx.ValidatorID) (i
 	return missedBlocks, missedTime, nil
 }
 
-func (b *EthAPIBackend) GetEpochState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.EpochState, error) {
+func (b *EthAPIBackend) GetEpochBlockState(ctx context.Context, epoch rpc.BlockNumber) (*iblockproc.BlockState, *iblockproc.EpochState, error) {
 	if epoch == rpc.PendingBlockNumber {
-		return nil, errors.New("pending epoch request isn't allowed")
+		bs, es := b.svc.store.GetBlockState(), b.svc.store.GetEpochState()
+		return &bs, &es, nil
 	}
 	if epoch == rpc.LatestBlockNumber {
 		epoch = rpc.BlockNumber(b.svc.store.GetEpoch())
 	}
-	return b.svc.store.GetHistoryEpochState(idx.Epoch(epoch)), nil
+	bs, es := b.svc.store.GetHistoryBlockEpochState(idx.Epoch(epoch))
+	return bs, es, nil
 }
 
 func (b *EthAPIBackend) CalcBlockExtApi() bool {

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -118,7 +118,7 @@ func (r *EvmStateReader) getBlock(h hash.Event, n idx.Block, readTxs bool) *evmc
 	}
 
 	// find block rules
-	epoch := r.store.FindBlockEpoch(n)
+	epoch := block.Atropos.Epoch()
 	es := r.store.GetHistoryEpochState(epoch)
 	var rules opera.Rules
 	if es != nil {

--- a/inter/validatorpk/pubkey.go
+++ b/inter/validatorpk/pubkey.go
@@ -20,15 +20,15 @@ var Types = struct {
 	Secp256k1: 0xc0,
 }
 
-func (pk *PubKey) Empty() bool {
+func (pk PubKey) Empty() bool {
 	return len(pk.Raw) == 0 && pk.Type == 0
 }
 
-func (pk *PubKey) String() string {
+func (pk PubKey) String() string {
 	return "0x" + common.Bytes2Hex(pk.Bytes())
 }
 
-func (pk *PubKey) Bytes() []byte {
+func (pk PubKey) Bytes() []byte {
 	return append([]byte{pk.Type}, pk.Raw...)
 }
 


### PR DESCRIPTION
- Add epoch number into header/block API output
- Add abft_getValidators API for retrieving validator weights and public keys
- Add ftm_getRules API call for retrieving network rules (e.g. throughput limits or upgrades activation status)
- Add ftm_getEpochBlock API call for retrieving block height in a beginning of an epoch