### PR TITLE
Check nil in topicsdb record fetch

### DIFF
--- a/topicsdb/record.go
+++ b/topicsdb/record.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/syndtr/goleveldb/leveldb/errors"
 )
 
 type (
@@ -39,6 +40,10 @@ func (rec *logrec) fetch(
 	)
 	buf, rec.err = logrecTable.Get(rec.ID.Bytes())
 	if rec.err != nil {
+		return
+	}
+	if buf == nil {
+		rec.err = errors.ErrNotFound
 		return
 	}
 


### PR DESCRIPTION
This PR fixes panics occurring during eth_getLogs call:
```
May 14 00:27:53 xapi173 opera[1587273]: ERROR[05-14|00:27:53.892] RPC method eth_getLogs crashed: runtime error: slice bounds out of range [:32] with capacity 0
May 14 00:27:53 xapi173 opera[1587273]: goroutine 398114963 [running]:
May 14 00:27:53 xapi173 opera[1587273]: github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
May 14 00:27:53 xapi173 opera[1587273]:         /home/opera/go/pkg/mod/github.com/hkalina/go-ethereum@v1.9.7-0.20220420181000-8998b2a3f533/rpc/service.go:204 +0x89
May 14 00:27:53 xapi173 opera[1587273]: panic({0x15327a0, 0xc01be8a6d8})
May 14 00:27:53 xapi173 opera[1587273]:         /usr/local/go/src/runtime/panic.go:838 +0x207
May 14 00:27:53 xapi173 opera[1587273]: github.com/Fantom-foundation/go-opera/topicsdb.(*logrec).fetch(0xc0bdd88780, {0x7f14400c9570, 0xc002cf5630})
May 14 00:27:53 xapi173 opera[1587273]:         /home/opera/go/src/go-opera/topicsdb/record.go:47 +0x4f3
May 14 00:27:53 xapi173 opera[1587273]: github.com/Fantom-foundation/go-opera/topicsdb.(*Index).ForEachInBlocks.func1(0xc0bdd88780)
May 14 00:27:53 xapi173 opera[1587273]:         /home/opera/go/src/go-opera/topicsdb/topicsdb.go:91 +0x57
May 14 00:27:53 xapi173 opera[1587273]: github.com/Fantom-foundation/go-opera/topicsdb.(*Index).walkNexts(0xc08e5d7da0?, {0x188eca0?, 0xc09d52be60?}, 0x66?, {0xc00684c990?, 0x8?, 0x8?}, 0x5?, 0xc01bed8fe0?)
May 14 00:27:53 xapi173 opera[1587273]:         /home/opera/go/src/go-opera/topicsdb/search_lazy.go:94 +0x15a
May 14 00:27:53 xapi173 opera[1587273]: github.com/Fantom-foundation/go-opera/topicsdb.(*Index).walkFirst(0xc002e9ad20, {0x188eca0, 0xc09d52be60}, {0xc09baf9590, 0x8, 0x8}, 0x2469600, {0xc00684c990, 0x2, 0x2}, ...)
May 14 00:27:53 xapi173 opera[1587273]:         /home/opera/go/src/go-opera/topicsdb/search_lazy.go:66 +0x465
May 14 00:27:53 xapi173 opera[1587273]: github.com/Fantom-foundation/go-opera/topicsdb.(*Index).searchLazy(0x18?, {0x188eca0?, 0xc09d52be60?}, {0xc00684c990?, 0xc00684c960?, 0x560000c006d8b674?}, {0xc09baf9590?, 0x0?, 0x8?}, 0x2469600, ...)
```
Because of topicsdb search_lazy implementation this panic also prevents correct releasing of the database iterator.