### PR TITLE
Fix of topicsdb RW-race

### DIFF
--- a/topicsdb/topicsdb.go
+++ b/topicsdb/topicsdb.go
@@ -3,7 +3,6 @@ package topicsdb
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
@@ -13,10 +12,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-const MaxTopicsCount = math.MaxUint8
+const MaxTopicsCount = 5 // count is limited hard to 5 by EVM (see LOG0...LOG4 ops)
 
 var (
-	ErrEmptyTopics = fmt.Errorf("Empty topics")
+	ErrEmptyTopics  = fmt.Errorf("Empty topics")
+	ErrTooBigTopics = fmt.Errorf("Too big topics")
 )
 
 // Index is a specialized indexes for log records storing and fetching.
@@ -147,14 +147,15 @@ func (tt *Index) MustPush(recs ...*types.Log) {
 // Write log record to database.
 func (tt *Index) Push(recs ...*types.Log) error {
 	for _, rec := range recs {
+		if len(rec.Topics) > MaxTopicsCount {
+			return ErrTooBigTopics
+		}
+
 		id := NewID(rec.BlockNumber, rec.TxHash, rec.Index)
 
 		// write data
 		buf := make([]byte, 0, common.HashLength*len(rec.Topics)+common.HashLength+common.AddressLength+len(rec.Data))
-		for j, topic := range rec.Topics {
-			if j >= MaxTopicsCount {
-				break // to don't overflow the pos
-			}
+		for _, topic := range rec.Topics {
 			buf = append(buf, topic.Bytes()...)
 		}
 		buf = append(buf, rec.BlockHash.Bytes()...)
@@ -182,10 +183,7 @@ func (tt *Index) Push(recs ...*types.Log) error {
 			return err
 		}
 
-		for j, topic := range rec.Topics {
-			if j >= MaxTopicsCount {
-				break // to don't overflow the pos
-			}
+		for _, topic := range rec.Topics {
 			if err := pushIndex(topic); err != nil {
 				return err
 			}

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -390,7 +390,10 @@ func TestPatternLimit(t *testing.T) {
 
 	for i, x := range data {
 		got, err := limitPattern(x.pattern)
-		require.ElementsMatch(x.exp, got, i)
+		require.Equal(len(x.exp), len(got))
+		for j := range got {
+			require.ElementsMatch(x.exp[j], got[j], i, j)
+		}
 		require.Equal(x.err, err, i)
 	}
 }


### PR DESCRIPTION
Fix of read-write race #310 when log's index is already written and can be found but log's data is not yet.
Also includes:
 - test fix;
 - the meaning of max topics count;