### PR TITLE
Add indexing for network upgrades

### DIFF
--- a/gossip/api.go
+++ b/gossip/api.go
@@ -33,5 +33,5 @@ func (api *PublicEthereumAPI) Hashrate() hexutil.Uint64 {
 
 // ChainId is the EIP-155 replay-protection chain id for the current ethereum chain config.
 func (api *PublicEthereumAPI) ChainId() hexutil.Uint64 {
-	return hexutil.Uint64(api.s.store.GetRules().EvmChainConfig().ChainID.Uint64())
+	return hexutil.Uint64(api.s.store.GetRules().NetworkID)
 }

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 
+	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
@@ -31,6 +32,11 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (genesisHash hash.Hash, err erro
 	if topEr == nil {
 		return genesisHash, errors.New("no ERs in genesis")
 	}
+	var prevEs *iblockproc.EpochState
+	s.ForEachHistoryBlockEpochState(func(bs iblockproc.BlockState, es iblockproc.EpochState) bool {
+		s.WriteUpgradeHeight(bs, es, prevEs)
+		return true
+	})
 	s.SetBlockEpochState(topEr.BlockState, topEr.EpochState)
 	s.FlushBlockEpochState()
 

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/inter"
@@ -51,5 +52,5 @@ type EVMProcessor interface {
 }
 
 type EVM interface {
-	Start(block iblockproc.BlockCtx, statedb *state.StateDB, reader evmcore.DummyChain, onNewLog func(*types.Log), net opera.Rules) EVMProcessor
+	Start(block iblockproc.BlockCtx, statedb *state.StateDB, reader evmcore.DummyChain, onNewLog func(*types.Log), net opera.Rules, evmCfg *params.ChainConfig) EVMProcessor
 }

--- a/gossip/c_llr_callbacks.go
+++ b/gossip/c_llr_callbacks.go
@@ -12,8 +12,10 @@ import (
 	"github.com/Fantom-foundation/go-opera/eventcheck"
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/inter"
+	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
+	"github.com/Fantom-foundation/go-opera/opera"
 )
 
 var errValidatorNotExist = errors.New("validator does not exist")
@@ -238,6 +240,15 @@ func (s *Store) WriteFullEpochRecord(er ier.LlrIdxFullEpochRecord) {
 	s.SetEpochBlock(er.BlockState.LastBlock.Idx+1, er.Idx)
 }
 
+func (s *Store) WriteUpgradeHeight(bs iblockproc.BlockState, es iblockproc.EpochState, prevEs *iblockproc.EpochState) {
+	if prevEs == nil || es.Rules.Upgrades != prevEs.Rules.Upgrades {
+		s.AddUpgradeHeight(opera.UpgradeHeight{
+			Upgrades: es.Rules.Upgrades,
+			Height:   bs.LastBlock.Idx + 1,
+		})
+	}
+}
+
 func (s *Service) ProcessFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
 	// engineMu should NOT be locked here
 	if s.store.HasHistoryBlockEpochState(er.Idx) {
@@ -256,6 +267,7 @@ func (s *Service) ProcessFullEpochRecord(er ier.LlrIdxFullEpochRecord) error {
 	}
 
 	s.store.WriteFullEpochRecord(er)
+	s.store.WriteUpgradeHeight(er.BlockState, er.EpochState, s.store.GetHistoryEpochState(er.EpochState.Epoch-1))
 	s.engineMu.Lock()
 	defer s.engineMu.Unlock()
 	updateLowestEpochToFill(er.Idx, s.store)

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -454,7 +454,7 @@ func (env *testEnv) callContract(
 	// about the transaction and calling mechanisms.
 	txContext := evmcore.NewEVMTxContext(msg)
 	context := evmcore.NewEVMBlockContext(block.Header(), env.GetEvmStateReader(), nil)
-	vmenv := vm.NewEVM(context, txContext, state, env.store.GetRules().EvmChainConfig(), opera.DefaultVMConfig)
+	vmenv := vm.NewEVM(context, txContext, state, env.store.GetEvmChainConfig(), opera.DefaultVMConfig)
 	gaspool := new(evmcore.GasPool).AddGas(math.MaxUint64)
 	res, err := evmcore.NewStateTransition(vmenv, msg, gaspool).TransitionDb()
 

--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -63,6 +63,6 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 func currentENREntry(svc *Service) *enrEntry {
 	genesisHash := *svc.store.GetGenesisID()
 	return &enrEntry{
-		ForkID: forkid.NewID(svc.store.GetRules().EvmChainConfig(), common.Hash(genesisHash), uint64(svc.store.GetLatestBlockIndex())),
+		ForkID: forkid.NewID(svc.store.GetEvmChainConfig(), common.Hash(genesisHash), uint64(svc.store.GetLatestBlockIndex())),
 	}
 }

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -41,7 +41,7 @@ type EthAPIBackend struct {
 
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
-	return b.svc.store.GetRules().EvmChainConfig()
+	return b.svc.store.GetEvmChainConfig()
 }
 
 func (b *EthAPIBackend) CurrentBlock() *evmcore.EvmBlock {

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -64,7 +64,7 @@ func (r *EvmStateReader) MaxGasLimit() uint64 {
 }
 
 func (r *EvmStateReader) Config() *params.ChainConfig {
-	return r.store.GetRules().EvmChainConfig()
+	return r.store.GetEvmChainConfig()
 }
 
 func (r *EvmStateReader) CurrentBlock() *evmcore.EvmBlock {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -208,13 +208,14 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	svc.store.GetLastBVs()
 	svc.store.GetLastEVs()
 	svc.store.GetLlrState()
+	svc.store.GetUpgradeHeights()
 
 	// create GPO
 	svc.gpo = gasprice.NewOracle(svc.config.GPO)
 
 	// create checkers
 	net := store.GetRules()
-	txSigner := gsignercache.Wrap(types.LatestSignerForChainID(net.EvmChainConfig().ChainID))
+	txSigner := gsignercache.Wrap(types.LatestSignerForChainID(new(big.Int).SetUint64(net.NetworkID)))
 	svc.heavyCheckReader.Store = store
 	svc.heavyCheckReader.Pubkeys.Store(readEpochPubKeys(svc.store, svc.store.GetEpoch()))                                          // read pub keys of current epoch from DB
 	svc.gasPowerCheckReader.Ctx.Store(NewGasPowerContext(svc.store, svc.store.GetValidators(), svc.store.GetEpoch(), net.Economy)) // read gaspower check data from DB

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -39,6 +39,7 @@ type Store struct {
 		Blocks                 kvdb.Store `table:"b"`
 		EpochBlocks            kvdb.Store `table:"P"`
 		Genesis                kvdb.Store `table:"g"`
+		UpgradeHeights         kvdb.Store `table:"U"`
 
 		// P2P-only
 		HighestLamport kvdb.Store `table:"l"`
@@ -73,10 +74,11 @@ type Store struct {
 		BlockEpochStateHistory *wlru.Cache  `cache:"-"` // store by pointer
 		BlockEpochState        atomic.Value // store by value
 		HighestLamport         atomic.Value // store by value
-		LastBVs                atomic.Value
-		LastEV                 atomic.Value
-		LlrState               atomic.Value
-		KvdbEvmSnap            atomic.Value
+		LastBVs                atomic.Value // store by pointer
+		LastEV                 atomic.Value // store by pointer
+		LlrState               atomic.Value // store by value
+		KvdbEvmSnap            atomic.Value // store by pointer
+		UpgradeHeights         atomic.Value // store by pointer
 	}
 
 	mutex struct {

--- a/gossip/store_activation_heights.go
+++ b/gossip/store_activation_heights.go
@@ -1,0 +1,27 @@
+package gossip
+
+import (
+	"github.com/Fantom-foundation/go-opera/opera"
+)
+
+func (s *Store) AddUpgradeHeight(h opera.UpgradeHeight) {
+	orig := s.GetUpgradeHeights()
+	// allocate new memory to avoid race condition in cache
+	cp := make([]opera.UpgradeHeight, 0, len(orig)+1)
+	cp = append(append(cp, orig...), h)
+
+	s.rlp.Set(s.table.UpgradeHeights, []byte{}, cp)
+	s.cache.UpgradeHeights.Store(cp)
+}
+
+func (s *Store) GetUpgradeHeights() []opera.UpgradeHeight {
+	if v := s.cache.UpgradeHeights.Load(); v != nil {
+		return v.([]opera.UpgradeHeight)
+	}
+	hh, ok := s.rlp.Get(s.table.Blocks, []byte{}, &[]opera.UpgradeHeight{}).(*[]opera.UpgradeHeight)
+	if !ok {
+		return []opera.UpgradeHeight{}
+	}
+	s.cache.UpgradeHeights.Store(*hh)
+	return *hh
+}

--- a/gossip/store_migration.go
+++ b/gossip/store_migration.go
@@ -48,7 +48,8 @@ func (s *Store) migrations() *migration.Migration {
 		Next("LlrState recovery", s.recoverLlrState).
 		Next("erase gossip-async db", s.eraseGossipAsyncDB).
 		Next("erase SFC API table", s.eraseSfcApiTable).
-		Next("erase legacy genesis DB", s.eraseGenesisDB)
+		Next("erase legacy genesis DB", s.eraseGenesisDB).
+		Next("calculate upgrade heights", s.calculateUpgradeHeights)
 }
 
 func unsupportedMigration() error {
@@ -403,6 +404,14 @@ func (s *Store) eraseGenesisDB() error {
 
 	_ = genesisDB.Close()
 	genesisDB.Drop()
+	return nil
+}
 
+func (s *Store) calculateUpgradeHeights() error {
+	var prevEs *iblockproc.EpochState
+	s.ForEachHistoryBlockEpochState(func(bs iblockproc.BlockState, es iblockproc.EpochState) bool {
+		s.WriteUpgradeHeight(bs, es, prevEs)
+		return true
+	})
 	return nil
 }

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
+	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
 	"github.com/Fantom-foundation/go-opera/opera/genesisstore"
 	"github.com/Fantom-foundation/go-opera/utils/iodb"
@@ -140,7 +141,12 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es, b.tmpStateDB)
 	evmProcessor := blockProc.EVMModule.Start(blockCtx, b.tmpStateDB, dummyHeaderReturner{}, func(l *types.Log) {
 		txListener.OnNewLog(l)
-	}, es.Rules)
+	}, es.Rules, es.Rules.EvmChainConfig([]opera.UpgradeHeight{
+		{
+			Upgrades: es.Rules.Upgrades,
+			Height:   0,
+		},
+	}))
 
 	// Execute genesis transactions
 	evmProcessor.Execute(genesisTxs)

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -12,5 +12,9 @@ func UpdateRules(src Rules, diff []byte) (res Rules, err error) {
 	res = changed
 	res.NetworkID = src.NetworkID
 	res.Name = src.Name
+	// don't allow to revert an activated upgrade
+	res.Upgrades.Berlin = res.Upgrades.Berlin || src.Upgrades.Berlin
+	res.Upgrades.London = res.Upgrades.London || src.Upgrades.London
+	res.Upgrades.Llr = res.Upgrades.Llr || src.Upgrades.Llr
 	return
 }


### PR DESCRIPTION
- add indexing of upgrade heights to allow historical execution transaction with accurate upgrades (for API use)
- don't allow to revert an activated upgrades