### PR TITLE
Cache NetworkVersion in VerWarcher

### DIFF
--- a/gossip/blockproc/verwatcher/store.go
+++ b/gossip/blockproc/verwatcher/store.go
@@ -1,6 +1,8 @@
 package verwatcher
 
 import (
+	"sync/atomic"
+
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 
 	"github.com/Fantom-foundation/go-opera/logger"
@@ -9,6 +11,11 @@ import (
 // Store is a node persistent storage working over physical key-value database.
 type Store struct {
 	mainDB kvdb.Store
+
+	cache struct {
+		networkVersion atomic.Value
+		missedVersion  atomic.Value
+	}
 
 	logger.Instance
 }

--- a/gossip/blockproc/verwatcher/store_network_version.go
+++ b/gossip/blockproc/verwatcher/store_network_version.go
@@ -11,6 +11,7 @@ const (
 
 // SetNetworkVersion stores network version.
 func (s *Store) SetNetworkVersion(v uint64) {
+	s.cache.networkVersion.Store(v)
 	err := s.mainDB.Put([]byte(nvKey), bigendian.Uint64ToBytes(v))
 	if err != nil {
 		s.Log.Crit("Failed to put key", "err", err)
@@ -19,19 +20,24 @@ func (s *Store) SetNetworkVersion(v uint64) {
 
 // GetNetworkVersion returns stored network version.
 func (s *Store) GetNetworkVersion() uint64 {
+	if v := s.cache.networkVersion.Load(); v != nil {
+		return v.(uint64)
+	}
 	valBytes, err := s.mainDB.Get([]byte(nvKey))
 	if err != nil {
 		s.Log.Crit("Failed to get key", "err", err)
 	}
-	if valBytes == nil {
-		return 0
+	v := uint64(0)
+	if valBytes != nil {
+		v = bigendian.BytesToUint64(valBytes)
 	}
-
-	return bigendian.BytesToUint64(valBytes)
+	s.cache.networkVersion.Store(v)
+	return v
 }
 
 // SetMissedVersion stores non-supported network upgrade.
 func (s *Store) SetMissedVersion(v uint64) {
+	s.cache.missedVersion.Store(v)
 	err := s.mainDB.Put([]byte(mvKey), bigendian.Uint64ToBytes(v))
 	if err != nil {
 		s.Log.Crit("Failed to put key", "err", err)
@@ -40,13 +46,17 @@ func (s *Store) SetMissedVersion(v uint64) {
 
 // GetMissedVersion returns stored non-supported network upgrade.
 func (s *Store) GetMissedVersion() uint64 {
+	if v := s.cache.missedVersion.Load(); v != nil {
+		return v.(uint64)
+	}
 	valBytes, err := s.mainDB.Get([]byte(mvKey))
 	if err != nil {
 		s.Log.Crit("Failed to get key", "err", err)
 	}
-	if valBytes == nil {
-		return 0
+	v := uint64(0)
+	if valBytes != nil {
+		v = bigendian.BytesToUint64(valBytes)
 	}
-
-	return bigendian.BytesToUint64(valBytes)
+	s.cache.missedVersion.Store(v)
+	return v
 }

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -202,6 +202,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	svc.dagIndexer.Reset(svc.store.GetValidators(), es.table.DagIndex, func(id hash.Event) dag.Event {
 		return svc.store.GetEvent(id)
 	})
+
 	// load caches for mutable values to avoid race condition
 	svc.store.GetBlockEpochState()
 	svc.store.GetHighestLamport()
@@ -209,6 +210,9 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	svc.store.GetLastEVs()
 	svc.store.GetLlrState()
 	svc.store.GetUpgradeHeights()
+	netVerStore := verwatcher.NewStore(store.table.NetworkVersion)
+	netVerStore.GetNetworkVersion()
+	netVerStore.GetMissedVersion()
 
 	// create GPO
 	svc.gpo = gasprice.NewOracle(svc.config.GPO)
@@ -266,7 +270,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{config.ExtRPCEnabled, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
 
-	svc.verWatcher = verwatcher.New(verwatcher.NewStore(store.table.NetworkVersion))
+	svc.verWatcher = verwatcher.New(netVerStore)
 	svc.tflusher = svc.makePeriodicFlusher()
 
 	return svc, nil


### PR DESCRIPTION
Go-Opera currently consume 5% of all database reading time in repeated reading of NetVersion:

![image](https://user-images.githubusercontent.com/3178122/172868844-99706a59-8a11-49be-ab22-487f6e6270c9.png)

This pull requests adds cache into the VerWatcher Store, which reduce this to almost zero - the value is loaded from the database only once and keep up-to-date in the cache on updates.