### PR TITLE
Checking build at every commit and releasing tags

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,12 +1,9 @@
-name: Release
+name: Check build
 
-on:
-  push:
-    tags:
-    - '*'
+on: [push]
 
 jobs:
-  release:
+  check-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,8 +17,8 @@ jobs:
       - name: Build
         run: make opera
 
-      - name: Release
-        uses: ncipollo/release-action@v1
+      - name: Publish
+        uses: actions/upload-artifact@v2
         with:
-          artifacts: "./build/opera"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          name: opera
+          path: ./build/opera


### PR DESCRIPTION
Hello, this is really small PR, but I think it would be very useful for wider adoption.

E.g. I'm experimenting with different networks and capability to download binary build would really ease my life since, in this case, I could just take any fresh cloud instance, download the binary using my scripts and run my tests. No need to install Go on target machine and compile stuff from scratch (which isn't hard but takes time especially if it's automated testing environment). I haven't used your template since it isn't a package and nothing really changed in the code itself. Only publishing archive with fresh binary build.

Please, let me know if this can be merged and what changes it needs for this. We can limit building for particular versions although I think it is useful to check build every commit.