### PR TITLE
fix of default bootnodes value

### DIFF
--- a/cmd/opera/launcher/config_custom.go
+++ b/cmd/opera/launcher/config_custom.go
@@ -1,0 +1,79 @@
+package launcher
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/naoina/toml"
+	"github.com/naoina/toml/ast"
+)
+
+// asDefault is slice with one empty element
+// which indicates that network default bootnodes should be substituted
+var asDefault = []*enode.Node{{}}
+
+func needDefaultBootnodes(nn []*enode.Node) bool {
+	return len(nn) == len(asDefault) && nn[0] == asDefault[0]
+}
+
+func isBootstrapNodesDefault(root *ast.Table) (
+	bootstrapNodes bool,
+	bootstrapNodesV5 bool,
+) {
+	table := root
+	for _, path := range []string{"Node", "P2P"} {
+		val, ok := table.Fields[path]
+		if !ok {
+			return
+		}
+		table = val.(*ast.Table)
+	}
+
+	emptyNode := fmt.Sprintf("\"%s\"", asDefault[0])
+
+	var res = map[string]bool{
+		"BootstrapNodes":   false,
+		"BootstrapNodesV5": false,
+	}
+	for name := range res {
+		if val, ok := table.Fields[name]; ok {
+			kv := val.(*ast.KeyValue)
+			arr := kv.Value.(*ast.Array)
+			if len(arr.Value) == len(asDefault) && arr.Value[0].Source() == emptyNode {
+				res[name] = true
+				delete(table.Fields, name)
+			}
+		}
+	}
+	bootstrapNodes = res["BootstrapNodes"]
+	bootstrapNodesV5 = res["BootstrapNodesV5"]
+
+	return
+}
+
+// UnmarshalTOML implements toml.Unmarshaler.
+func (c *config) UnmarshalTOML(input []byte) error {
+	ast, err := toml.Parse(input)
+	if err != nil {
+		return err
+	}
+
+	defaultBootstrapNodes, defaultBootstrapNodesV5 := isBootstrapNodesDefault(ast)
+
+	type rawCfg config
+	var raw rawCfg
+	err = toml.UnmarshalTable(ast, &raw)
+	if err != nil {
+		return err
+	}
+	*c = config(raw)
+
+	if defaultBootstrapNodes {
+		c.Node.P2P.BootstrapNodes = asDefault
+	}
+	if defaultBootstrapNodesV5 {
+		c.Node.P2P.BootstrapNodesV5 = asDefault
+	}
+
+	return nil
+}

--- a/cmd/opera/launcher/config_custom_test.go
+++ b/cmd/opera/launcher/config_custom_test.go
@@ -1,0 +1,58 @@
+package launcher
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/abft"
+	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Fantom-foundation/go-opera/evmcore"
+	"github.com/Fantom-foundation/go-opera/gossip"
+	"github.com/Fantom-foundation/go-opera/gossip/emitter"
+	"github.com/Fantom-foundation/go-opera/vecmt"
+)
+
+func TestConfigTOML(t *testing.T) {
+	cacheRatio := cachescale.Ratio{
+		Base:   uint64(DefaultCacheSize*1 - ConstantCacheSize),
+		Target: uint64(DefaultCacheSize*2 - ConstantCacheSize),
+	}
+
+	src := config{
+		Node:          defaultNodeConfig(),
+		Opera:         gossip.DefaultConfig(cacheRatio),
+		Emitter:       emitter.DefaultConfig(),
+		TxPool:        evmcore.DefaultTxPoolConfig,
+		OperaStore:    gossip.DefaultStoreConfig(cacheRatio),
+		Lachesis:      abft.DefaultConfig(),
+		LachesisStore: abft.DefaultStoreConfig(cacheRatio),
+		VectorClock:   vecmt.DefaultConfig(cacheRatio),
+		cachescale:    cacheRatio,
+	}
+
+	for name, val := range map[string][]*enode.Node{
+		"Nil":     nil,
+		"Empty":   {},
+		"Default": asDefault,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			src.Node.P2P.BootstrapNodes = val
+			src.Node.P2P.BootstrapNodesV5 = val
+
+			stream, err := tomlSettings.Marshal(&src)
+			require.NoError(err)
+
+			var got config
+			err = tomlSettings.NewDecoder(bytes.NewReader(stream)).Decode(&got)
+			require.NoError(err)
+
+			require.Equal(src.Node.P2P.BootstrapNodes, got.Node.P2P.BootstrapNodes)
+			require.Equal(src.Node.P2P.BootstrapNodesV5, got.Node.P2P.BootstrapNodesV5)
+		})
+	}
+}

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -307,7 +307,7 @@ func makeNode(ctx *cli.Context, cfg *config, genesisStore *genesisstore.Store) (
 	if len(networkName) == 0 && genesisStore != nil {
 		networkName = genesisStore.Header().NetworkName
 	}
-	if len(cfg.Node.P2P.BootstrapNodes) == len(asDefault) && cfg.Node.P2P.BootstrapNodes[0] == asDefault[0] {
+	if needDefaultBootnodes(cfg.Node.P2P.BootstrapNodes) {
 		bootnodes := Bootnodes[networkName]
 		if bootnodes == nil {
 			bootnodes = []string{}

--- a/cmd/opera/launcher/params.go
+++ b/cmd/opera/launcher/params.go
@@ -2,7 +2,9 @@ package launcher
 
 import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -25,9 +27,6 @@ var (
 			"enode://1703640d1239434dcaf010541cafeeb3c4c707be9098954c50aa705f6e97e2d0273671df13f6e447563e7d3a7c7ffc88de48318d8a3cc2cc59d196516054f17e@52.72.222.228:7946",
 		},
 	}
-
-	// asDefault is slice with one empty element which indicates that network default bootnodes should be substituted
-	asDefault = []*enode.Node{{}}
 
 	mainnetHeader = genesis.Header{
 		GenesisID:   hash.HexToHash("0x4a53c5445584b3bfc20dbfb2ec18ae20037c716f3ba2d9e1da768a9deca17cb4"),
@@ -155,4 +154,19 @@ func overrideParams() {
 	params.RopstenBootnodes = []string{}
 	params.RinkebyBootnodes = []string{}
 	params.GoerliBootnodes = []string{}
+}
+
+// asDefault is slice with one fake element which indicates that network default bootnodes should be substituted
+var asDefault = fakeBootnodes()
+
+func fakeBootnodes() []*enode.Node {
+	privkey, _ := crypto.HexToECDSA("0b10b00000000000000000000000000000000000000000000000000000000000")
+	r := &enr.Record{}
+	enode.SignV4(r, privkey)
+	n, _ := enode.New(enode.ValidSchemes, r)
+	return []*enode.Node{n}
+}
+
+func needDefaultBootnodes(nn []*enode.Node) bool {
+	return len(nn) == len(asDefault) && nn[0] == asDefault[0]
 }

--- a/cmd/opera/launcher/params.go
+++ b/cmd/opera/launcher/params.go
@@ -2,9 +2,6 @@ package launcher
 
 import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -154,19 +151,4 @@ func overrideParams() {
 	params.RopstenBootnodes = []string{}
 	params.RinkebyBootnodes = []string{}
 	params.GoerliBootnodes = []string{}
-}
-
-// asDefault is slice with one fake element which indicates that network default bootnodes should be substituted
-var asDefault = fakeBootnodes()
-
-func fakeBootnodes() []*enode.Node {
-	privkey, _ := crypto.HexToECDSA("0b10b00000000000000000000000000000000000000000000000000000000000")
-	r := &enr.Record{}
-	enode.SignV4(r, privkey)
-	n, _ := enode.New(enode.ValidSchemes, r)
-	return []*enode.Node{n}
-}
-
-func needDefaultBootnodes(nn []*enode.Node) bool {
-	return len(nn) == len(asDefault) && nn[0] == asDefault[0]
 }


### PR DESCRIPTION
Special (one empty node) value of bootnodes is using to determine when we should use network default values.
But `go-ethereum/p2p/enode.Node` can't parse this value because of empty is not valid:
```
./opera dumpconfig > example.cfg
./opera --config=example.cfg
Fatal: TOML config file error: 1.1.1-rc.1.cfg, line 17: (p2p.Config.BootstrapNodes) EOF.
Use 'dumpconfig' command to get an example config file.

```
PR detects empty node before parsing, on AST stage.

The others way to fix it were more complicated in terms of maintain (IMHO):

1. Replace empty node with fake node (it was implemented as fast solution);
2. Modify `ethereum/go-ethereum/p2p/enode` to allow empty node parsing;
3. Use modified copy of config struct inside config.UnmarshalTOML();
