### PR TITLE
Forbid unlocking accounts with enabled external RPC

### DIFF
--- a/gossip/config.go
+++ b/gossip/config.go
@@ -100,8 +100,6 @@ type (
 		// allows only for EIP155 transactions.
 		AllowUnprotectedTxs bool
 
-		ExtRPCEnabled bool
-
 		RPCBlockExt bool
 	}
 

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -39,6 +39,11 @@ type EthAPIBackend struct {
 	allowUnprotectedTxs bool
 }
 
+// SetExtRPCEnabled updates extRPCEnabled
+func (b *EthAPIBackend) SetExtRPCEnabled(v bool) {
+	b.extRPCEnabled = v
+}
+
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.svc.store.GetEvmChainConfig()

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -172,6 +172,7 @@ func NewService(stack *node.Node, config Config, store *Store, blockProc BlockPr
 	svc.p2pServer = stack.Server()
 	svc.accountManager = stack.AccountManager()
 	svc.eventMux = stack.EventMux()
+	svc.EthAPI.SetExtRPCEnabled(stack.Config().ExtRPCEnabled())
 	// Create the net API service
 	svc.netRPCService = ethapi.NewPublicNetAPI(svc.p2pServer, store.GetRules().NetworkID)
 	svc.haltCheck = haltCheck
@@ -269,7 +270,7 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	}
 
 	// create API backend
-	svc.EthAPI = &EthAPIBackend{config.ExtRPCEnabled, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
+	svc.EthAPI = &EthAPIBackend{false, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
 
 	svc.verWatcher = verwatcher.New(netVerStore)
 	svc.tflusher = svc.makePeriodicFlusher()


### PR DESCRIPTION
- fix initialization of ExtRPCEnabled var so that unlocking of accounts is forbidden unless `--allow-insecure-unlock` argument is added