### PR TITLE
fix nil cachescale issue after loading toml config file

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -369,7 +369,6 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 		Lachesis:      abft.DefaultConfig(),
 		LachesisStore: abft.DefaultStoreConfig(cacheRatio),
 		VectorClock:   vecmt.DefaultConfig(cacheRatio),
-		cachescale:    cacheRatio,
 	}
 
 	if ctx.GlobalIsSet(FakeNetFlag.Name) {
@@ -388,6 +387,8 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 			return &cfg, err
 		}
 	}
+
+	cfg.cachescale = cacheRatio
 
 	// Apply flags (high priority)
 	var err error


### PR DESCRIPTION
Set **cachescale** to default `cacheRatio` after loading config file to avoid nil pointer exception when running node with toml config file  

It seems the side effect of https://github.com/Fantom-foundation/go-opera/pull/337