### PR TITLE
Fix genesis export

### DIFF
--- a/cmd/opera/launcher/genesiscmd.go
+++ b/cmd/opera/launcher/genesiscmd.go
@@ -323,7 +323,7 @@ func exportGenesis(ctx *cli.Context) error {
 	if mode != "none" {
 		log.Info("Exporting EVM data", "from", fromBlock, "to", toBlock)
 		writer := newUnitWriter(plain)
-		err := writer.Start(header, genesisstore.BlocksSection, tmpPath)
+		err := writer.Start(header, genesisstore.EvmSection, tmpPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Trivial fix of the genesis file export.

Currently when I export the genesis file:
```
../build/opera --datadir opera0.datadir export genesis my-genesis.g
```
Starting a new node using the genesis file fails, because of duplicated BlocksSection:
```
../build/opera --genesis my-genesis.g --datadir operaX.datadir --genesis.allowExperimental
INFO [07-26|14:18:23.463] Maximum peer count                       total=50
INFO [07-26|14:18:23.463] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
Fatal: Failed to read genesis file: unit name is duplicated
```
This fixes the workflow.