### PR TITLE
Use only alphanumerical prefixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc6
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc6 h1:QAOlomYdCyfP2Z8fRFEfzYYPxMLqUMbvppOGhOoVarM=
-github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc6/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
+github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7 h1:wt1bhCeb3E0qzDV2iuv2qYlNDO/j8DFJfzVHSnevVOU=
+github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220811115347-2434192efadb h1:kyCcawuYwMe+FJy0KYRFqGWrHYNoGixO9QTIceD8ngM=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220811115347-2434192efadb/go.mod h1:CFMonaK1v/QHwpjLszuycFDgLXNazZqZxciwhKwXDVQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=

--- a/gossip/store.go
+++ b/gossip/store.go
@@ -51,15 +51,15 @@ type Store struct {
 		// API-only
 		BlockHashes kvdb.Store `table:"B"`
 
-		LlrState           kvdb.Store `table:"!"`
-		LlrBlockResults    kvdb.Store `table:"@"`
-		LlrEpochResults    kvdb.Store `table:"#"`
-		LlrBlockVotes      kvdb.Store `table:"$"`
-		LlrBlockVotesIndex kvdb.Store `table:"%"`
-		LlrEpochVotes      kvdb.Store `table:"^"`
-		LlrEpochVoteIndex  kvdb.Store `table:"&"`
-		LlrLastBlockVotes  kvdb.Store `table:"*"`
-		LlrLastEpochVote   kvdb.Store `table:"("`
+		LlrState           kvdb.Store `table:"S"`
+		LlrBlockResults    kvdb.Store `table:"R"`
+		LlrEpochResults    kvdb.Store `table:"Q"`
+		LlrBlockVotes      kvdb.Store `table:"T"`
+		LlrBlockVotesIndex kvdb.Store `table:"J"`
+		LlrEpochVotes      kvdb.Store `table:"E"`
+		LlrEpochVoteIndex  kvdb.Store `table:"I"`
+		LlrLastBlockVotes  kvdb.Store `table:"G"`
+		LlrLastEpochVote   kvdb.Store `table:"F"`
 	}
 
 	prevFlushTime time.Time

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -155,6 +155,37 @@ func newClosableTable(db kvdb.Store, prefix []byte) *closebaleTable {
 	}
 }
 
+func translateGossipPrefix(p byte) byte {
+	if p == byte('!') {
+		return byte('S')
+	}
+	if p == byte('@') {
+		return byte('R')
+	}
+	if p == byte('#') {
+		return byte('Q')
+	}
+	if p == byte('$') {
+		return byte('T')
+	}
+	if p == byte('%') {
+		return byte('J')
+	}
+	if p == byte('^') {
+		return byte('E')
+	}
+	if p == byte('&') {
+		return byte('I')
+	}
+	if p == byte('*') {
+		return byte('G')
+	}
+	if p == byte('(') {
+		return byte('F')
+	}
+	return p
+}
+
 func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer) error {
 	if !isEmpty(path.Join(chaindataDir, "gossip")) {
 		// migrate DB layout
@@ -207,8 +238,8 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer) error {
 		}
 
 		// move gossip DB
-		// move logs
 
+		// move logs
 		mustTransform(transformTask{
 			openSrc: func() kvdb.Store {
 				return newClosableTable(openOldDB("gossip"), []byte("Lr"))
@@ -244,7 +275,7 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer) error {
 					if b == int('M') || b == int('r') || b == int('x') || b == int('X') {
 						return openNewDB("evm/" + string([]byte{byte(b)}))
 					} else {
-						return openNewDB("gossip/" + string([]byte{byte(b)}))
+						return openNewDB("gossip/" + string([]byte{translateGossipPrefix(byte(b))}))
 					}
 				},
 				name:    fmt.Sprintf("gossip/%c", rune(b)),

--- a/integration/routing.go
+++ b/integration/routing.go
@@ -22,7 +22,7 @@ func DefaultRoutingConfig() RoutingConfig {
 			"lachesis": {
 				Type:  "pebble-fsh",
 				Name:  "main",
-				Table: ">",
+				Table: "L",
 			},
 			"gossip": {
 				Type: "pebble-fsh",


### PR DESCRIPTION
- change non-alphanumerical prefixes to be alphanumerical for the sake of compatibility with third party tools