### PR TITLE
Allow to preserve legacy DBs layout, use leveldb-only layout by default

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -351,7 +351,7 @@ func setDBConfig(ctx *cli.Context, cfg integration.DBsConfig, cacheRatio cachesc
 		if preset == "pbl-1" {
 			cfg = integration.Pbl1DBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
 		} else if preset == "ldb-1" {
-			utils.Fatalf("--%s: ldb-1 preset is not unsupported yet", DBPresetFlag.Name)
+			cfg = integration.Ldb1DBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
 		} else if preset == "legacy-ldb" {
 			cfg = integration.LdbLegacyDBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
 		} else if preset == "legacy-pbl" {

--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -348,15 +348,16 @@ func gossipStoreConfigWithFlags(ctx *cli.Context, src gossip.StoreConfig) (gossi
 func setDBConfig(ctx *cli.Context, cfg integration.DBsConfig, cacheRatio cachescale.Func) integration.DBsConfig {
 	if ctx.GlobalIsSet(DBPresetFlag.Name) {
 		preset := ctx.GlobalString(DBPresetFlag.Name)
-		if preset == "pbl-1" {
+		switch preset {
+		case "pbl-1":
 			cfg = integration.Pbl1DBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
-		} else if preset == "ldb-1" {
+		case "ldb-1":
 			cfg = integration.Ldb1DBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
-		} else if preset == "legacy-ldb" {
+		case "legacy-ldb":
 			cfg = integration.LdbLegacyDBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
-		} else if preset == "legacy-pbl" {
+		case "legacy-pbl":
 			cfg = integration.PblLegacyDBsConfig(cacheRatio.U64, uint64(utils.MakeDatabaseHandles()))
-		} else {
+		default:
 			utils.Fatalf("--%s must be 'pbl-1', 'ldb-1', 'legacy-pbl' or 'legacy-ldb'", DBPresetFlag.Name)
 		}
 	}

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -122,6 +122,8 @@ func initFlags() {
 		validatorPasswordFlag,
 		SyncModeFlag,
 		GCModeFlag,
+		DBPresetFlag,
+		DBMigrationModeFlag,
 	}
 	legacyRpcFlags = []cli.Flag{
 		utils.NoUSBFlag,

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -49,9 +49,9 @@ var (
 	snapshotStorageReadTimer = metrics.GetOrRegisterTimer("chain/snapshot/storage/reads", nil)
 	snapshotCommitTimer      = metrics.GetOrRegisterTimer("chain/snapshot/commits", nil)
 
-	blockInsertTimer     = metrics.GetOrRegisterTimer("chain/inserts", nil)
-	blockExecutionTimer  = metrics.GetOrRegisterTimer("chain/execution", nil)
-	blockWriteTimer      = metrics.GetOrRegisterTimer("chain/write", nil)
+	blockInsertTimer    = metrics.GetOrRegisterTimer("chain/inserts", nil)
+	blockExecutionTimer = metrics.GetOrRegisterTimer("chain/execution", nil)
+	blockWriteTimer     = metrics.GetOrRegisterTimer("chain/write", nil)
 )
 
 type ExtendedTxPosition struct {

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -242,6 +242,9 @@ func makeEngine(chaindataDir string, g *genesis.Genesis, genesisProc bool, cfg C
 // MakeEngine makes consensus engine from config.
 func MakeEngine(chaindataDir string, g *genesis.Genesis, cfg Configs) (*abft.Lachesis, *vecmt.Index, *gossip.Store, *abft.Store, gossip.BlockProc, func() error) {
 	// Legacy DBs migrate
+	if cfg.DBs.MigrationMode != "reformat" && cfg.DBs.MigrationMode != "rebuild" && cfg.DBs.MigrationMode != "" {
+		utils.Fatalf("MigrationMode must be 'reformat' or 'rebuild'")
+	}
 	if !isEmpty(path.Join(chaindataDir, "gossip")) {
 		MakeDBDirs(chaindataDir)
 		genesisProducers, _ := SupportedDBs(chaindataDir, cfg.DBs.GenesisCache)
@@ -249,7 +252,7 @@ func MakeEngine(chaindataDir string, g *genesis.Genesis, cfg Configs) (*abft.Lac
 		if err != nil {
 			utils.Fatalf("Failed to make engine: %v", err)
 		}
-		err = migrateLegacyDBs(chaindataDir, dbs)
+		err = migrateLegacyDBs(chaindataDir, dbs, cfg.DBs.MigrationMode)
 		_ = dbs.Close()
 		if err != nil {
 			utils.Fatalf("Failed to migrate state: %v", err)

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -252,7 +252,7 @@ func MakeEngine(chaindataDir string, g *genesis.Genesis, cfg Configs) (*abft.Lac
 		if err != nil {
 			utils.Fatalf("Failed to make engine: %v", err)
 		}
-		err = migrateLegacyDBs(chaindataDir, dbs, cfg.DBs.MigrationMode)
+		err = migrateLegacyDBs(chaindataDir, dbs, cfg.DBs.MigrationMode, cfg.DBs.Routing)
 		_ = dbs.Close()
 		if err != nil {
 			utils.Fatalf("Failed to migrate state: %v", err)

--- a/integration/db.go
+++ b/integration/db.go
@@ -39,8 +39,6 @@ type DBsCacheConfig struct {
 	Table map[string]DBCacheConfig
 }
 
-var DefaultDBsConfig = Pbl1DBsConfig
-
 func SupportedDBs(chaindataDir string, cfg DBsCacheConfig) (map[multidb.TypeName]kvdb.IterableDBProducer, map[multidb.TypeName]kvdb.FullDBProducer) {
 	if chaindataDir == "inmemory" || chaindataDir == "" {
 		chaindataDir, _ = ioutil.TempDir("", "opera-tmp")

--- a/integration/db.go
+++ b/integration/db.go
@@ -18,16 +18,16 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/utils/fmtfilter"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/go-opera/gossip"
 	"github.com/Fantom-foundation/go-opera/utils/dbutil/asyncflushproducer"
 )
 
 type DBsConfig struct {
-	Routing      RoutingConfig
-	RuntimeCache DBsCacheConfig
-	GenesisCache DBsCacheConfig
+	Routing       RoutingConfig
+	RuntimeCache  DBsCacheConfig
+	GenesisCache  DBsCacheConfig
+	MigrationMode string
 }
 
 type DBCacheConfig struct {
@@ -39,75 +39,7 @@ type DBsCacheConfig struct {
 	Table map[string]DBCacheConfig
 }
 
-func DefaultDBsConfig(scale func(uint64) uint64, fdlimit uint64) DBsConfig {
-	return DBsConfig{
-		Routing:      DefaultRoutingConfig(),
-		RuntimeCache: DefaultRuntimeDBsCacheConfig(scale, fdlimit),
-		GenesisCache: DefaultGenesisDBsCacheConfig(scale, fdlimit),
-	}
-}
-
-func DefaultRuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
-	return DBsCacheConfig{
-		Table: map[string]DBCacheConfig{
-			"evm-data": {
-				Cache:   scale(242 * opt.MiB),
-				Fdlimit: fdlimit*242/700 + 1,
-			},
-			"evm-logs": {
-				Cache:   scale(110 * opt.MiB),
-				Fdlimit: fdlimit*110/700 + 1,
-			},
-			"main": {
-				Cache:   scale(186 * opt.MiB),
-				Fdlimit: fdlimit*186/700 + 1,
-			},
-			"events": {
-				Cache:   scale(87 * opt.MiB),
-				Fdlimit: fdlimit*87/700 + 1,
-			},
-			"epoch-%d": {
-				Cache:   scale(75 * opt.MiB),
-				Fdlimit: fdlimit*75/700 + 1,
-			},
-			"": {
-				Cache:   64 * opt.MiB,
-				Fdlimit: fdlimit/100 + 1,
-			},
-		},
-	}
-}
-
-func DefaultGenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
-	return DBsCacheConfig{
-		Table: map[string]DBCacheConfig{
-			"main": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
-			},
-			"evm-data": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
-			},
-			"evm-logs": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
-			},
-			"events": {
-				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
-			},
-			"epoch-%d": {
-				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
-			},
-			"": {
-				Cache:   16 * opt.MiB,
-				Fdlimit: fdlimit/100 + 1,
-			},
-		},
-	}
-}
+var DefaultDBsConfig = Pbl1DBsConfig
 
 func SupportedDBs(chaindataDir string, cfg DBsCacheConfig) (map[multidb.TypeName]kvdb.IterableDBProducer, map[multidb.TypeName]kvdb.FullDBProducer) {
 	if chaindataDir == "inmemory" || chaindataDir == "" {

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -334,7 +334,7 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 					}
 				}
 			}
-		} else {
+		default:
 			return errors.New("missing --db.migration.mode flag")
 		}
 	}

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -300,7 +300,7 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 					dropSrc: b == 0xff,
 				})
 			}
-		} else if mode == "reformat" {
+		case "reformat":
 			if oldDBsType == "ldb" {
 				if !equalRoutingConfig(layout, LdbLegacyRoutingConfig()) {
 					return errors.New("reformatting DBs: missing --db.preset=legacy-ldb flag")

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -304,20 +304,32 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 				if !equalRoutingConfig(layout, LdbLegacyRoutingConfig()) {
 					return errors.New("reformatting DBs: missing --db.preset=legacy-ldb flag")
 				}
-				_ = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "leveldb-fsh", "main"))
+				err = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "leveldb-fsh", "main"))
+				if err != nil {
+					return err
+				}
 				for _, name := range oldDBs.Names() {
 					if strings.HasPrefix(name, "lachesis") || strings.HasPrefix(name, "gossip-") {
-						_ = os.Rename(path.Join(chaindataDir, name), path.Join(chaindataDir, "leveldb-fsh", name))
+						err = os.Rename(path.Join(chaindataDir, name), path.Join(chaindataDir, "leveldb-fsh", name))
+						if err != nil {
+							return err
+						}
 					}
 				}
 			} else {
 				if !equalRoutingConfig(layout, PblLegacyRoutingConfig()) {
 					return errors.New("reformatting DBs: missing --db.preset=legacy-pbl flag")
 				}
-				_ = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "pebble-fsh", "main"))
+				err = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "pebble-fsh", "main"))
+				if err != nil {
+					return err
+				}
 				for _, name := range oldDBs.Names() {
 					if strings.HasPrefix(name, "lachesis") || strings.HasPrefix(name, "gossip-") {
-						_ = os.Rename(path.Join(chaindataDir, name), path.Join(chaindataDir, "pebble-fsh", name))
+						err = os.Rename(path.Join(chaindataDir, name), path.Join(chaindataDir, "pebble-fsh", name))
+						if err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -199,7 +199,7 @@ func equalRoutingConfig(a, b RoutingConfig) bool {
 }
 
 func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode string, layout RoutingConfig) error {
-	if !isEmpty(path.Join(chaindataDir, "gossip")) {
+	{ // didn't erase the brackets to avoid massive code changes
 		// migrate DB layout
 		cacheFn, err := dbCacheFdlimit(DBsCacheConfig{
 			Table: map[string]DBCacheConfig{

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -236,7 +236,8 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 			return db
 		}
 
-		if mode == "rebuild" {
+		switch mode {
+		case "rebuild":
 			// move lachesis, lachesis-%d and gossip-%d DBs
 			for _, name := range oldDBs.Names() {
 				if strings.HasPrefix(name, "lachesis") || strings.HasPrefix(name, "gossip-") {

--- a/integration/presets.go
+++ b/integration/presets.go
@@ -1,0 +1,426 @@
+package integration
+
+import (
+	"github.com/Fantom-foundation/lachesis-base/kvdb/multidb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+/*
+ * pbl-1 config
+ */
+
+func Pbl1DBsConfig(scale func(uint64) uint64, fdlimit uint64) DBsConfig {
+	return DBsConfig{
+		Routing:      Pbl1RoutingConfig(),
+		RuntimeCache: Pbl1RuntimeDBsCacheConfig(scale, fdlimit),
+		GenesisCache: Pbl1GenesisDBsCacheConfig(scale, fdlimit),
+	}
+}
+
+func Pbl1RoutingConfig() RoutingConfig {
+	return RoutingConfig{
+		Table: map[string]multidb.Route{
+			"": {
+				Type: "pebble-fsh",
+			},
+			"lachesis": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "L",
+			},
+			"gossip": {
+				Type: "pebble-fsh",
+				Name: "main",
+			},
+			"evm": {
+				Type: "pebble-fsh",
+				Name: "main",
+			},
+			"gossip/e": {
+				Type: "pebble-fsh",
+				Name: "events",
+			},
+			"evm/M": {
+				Type: "pebble-drc",
+				Name: "evm-data",
+			},
+			"evm-logs": {
+				Type: "pebble-fsh",
+				Name: "evm-logs",
+			},
+			"gossip-%d": {
+				Type:  "leveldb-fsh",
+				Name:  "epoch-%d",
+				Table: "G",
+			},
+			"lachesis-%d": {
+				Type:   "leveldb-fsh",
+				Name:   "epoch-%d",
+				Table:  "L",
+				NoDrop: true,
+			},
+		},
+	}
+}
+
+func Pbl1RuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"evm-data": {
+				Cache:   scale(242 * opt.MiB),
+				Fdlimit: fdlimit*242/700 + 1,
+			},
+			"evm-logs": {
+				Cache:   scale(110 * opt.MiB),
+				Fdlimit: fdlimit*110/700 + 1,
+			},
+			"main": {
+				Cache:   scale(186 * opt.MiB),
+				Fdlimit: fdlimit*186/700 + 1,
+			},
+			"events": {
+				Cache:   scale(87 * opt.MiB),
+				Fdlimit: fdlimit*87/700 + 1,
+			},
+			"epoch-%d": {
+				Cache:   scale(75 * opt.MiB),
+				Fdlimit: fdlimit*75/700 + 1,
+			},
+			"": {
+				Cache:   64 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+func Pbl1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(1024 * opt.MiB),
+				Fdlimit: fdlimit*1024/3072 + 1,
+			},
+			"evm-data": {
+				Cache:   scale(1024 * opt.MiB),
+				Fdlimit: fdlimit*1024/3072 + 1,
+			},
+			"evm-logs": {
+				Cache:   scale(1024 * opt.MiB),
+				Fdlimit: fdlimit*1024/3072 + 1,
+			},
+			"events": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"epoch-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"": {
+				Cache:   16 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+/*
+ * legacy-ldb config
+ */
+
+func LdbLegacyDBsConfig(scale func(uint64) uint64, fdlimit uint64) DBsConfig {
+	return DBsConfig{
+		Routing:      LdbLegacyRoutingConfig(),
+		RuntimeCache: LdbLegacyRuntimeDBsCacheConfig(scale, fdlimit),
+		GenesisCache: LdbLegacyGenesisDBsCacheConfig(scale, fdlimit),
+	}
+}
+
+func LdbLegacyRoutingConfig() RoutingConfig {
+	return RoutingConfig{
+		Table: map[string]multidb.Route{
+			"": {
+				Type: "leveldb-fsh",
+			},
+			"lachesis": {
+				Type: "leveldb-fsh",
+				Name: "lachesis",
+			},
+			"gossip": {
+				Type: "leveldb-fsh",
+				Name: "main",
+			},
+
+			"gossip/S": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "!",
+			},
+			"gossip/R": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "@",
+			},
+			"gossip/Q": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "#",
+			},
+
+			"gossip/T": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "$",
+			},
+			"gossip/J": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "%",
+			},
+			"gossip/E": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "^",
+			},
+
+			"gossip/I": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "&",
+			},
+			"gossip/G": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "*",
+			},
+			"gossip/F": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "(",
+			},
+
+			"evm": {
+				Type: "leveldb-fsh",
+				Name: "main",
+			},
+			"evm-logs": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "L",
+			},
+			"gossip-%d": {
+				Type: "leveldb-fsh",
+				Name: "gossip-%d",
+			},
+			"lachesis-%d": {
+				Type: "leveldb-fsh",
+				Name: "lachesis-%d",
+			},
+		},
+	}
+}
+
+func LdbLegacyRuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(564 * opt.MiB),
+				Fdlimit: fdlimit*564/700 + 1,
+			},
+			"lachesis": {
+				Cache:   scale(8 * opt.MiB),
+				Fdlimit: fdlimit*8/700 + 1,
+			},
+			"gossip-%d": {
+				Cache:   scale(64 * opt.MiB),
+				Fdlimit: fdlimit*64/700 + 1,
+			},
+			"lachesis-%d": {
+				Cache:   scale(64 * opt.MiB),
+				Fdlimit: fdlimit*64/700 + 1,
+			},
+			"": {
+				Cache:   64 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+func LdbLegacyGenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(3072 * opt.MiB),
+				Fdlimit: fdlimit*3072 + 1,
+			},
+			"lachesis": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"gossip-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"lachesis-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"": {
+				Cache:   16 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+/*
+ * legacy-pbl config
+ */
+
+func PblLegacyDBsConfig(scale func(uint64) uint64, fdlimit uint64) DBsConfig {
+	return DBsConfig{
+		Routing:      PblLegacyRoutingConfig(),
+		RuntimeCache: PblLegacyRuntimeDBsCacheConfig(scale, fdlimit),
+		GenesisCache: PblLegacyGenesisDBsCacheConfig(scale, fdlimit),
+	}
+}
+
+func PblLegacyRoutingConfig() RoutingConfig {
+	return RoutingConfig{
+		Table: map[string]multidb.Route{
+			"": {
+				Type: "pebble-fsh",
+			},
+			"lachesis": {
+				Type: "pebble-fsh",
+				Name: "lachesis",
+			},
+			"gossip": {
+				Type: "pebble-fsh",
+				Name: "main",
+			},
+
+			"gossip/S": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "!",
+			},
+			"gossip/R": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "@",
+			},
+			"gossip/Q": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "#",
+			},
+
+			"gossip/T": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "$",
+			},
+			"gossip/J": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "%",
+			},
+			"gossip/E": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "^",
+			},
+
+			"gossip/I": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "&",
+			},
+			"gossip/G": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "*",
+			},
+			"gossip/F": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "(",
+			},
+
+			"evm": {
+				Type: "pebble-fsh",
+				Name: "main",
+			},
+			"evm-logs": {
+				Type:  "pebble-fsh",
+				Name:  "main",
+				Table: "L",
+			},
+			"gossip-%d": {
+				Type: "pebble-fsh",
+				Name: "gossip-%d",
+			},
+			"lachesis-%d": {
+				Type: "pebble-fsh",
+				Name: "lachesis-%d",
+			},
+		},
+	}
+}
+
+func PblLegacyRuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(564 * opt.MiB),
+				Fdlimit: fdlimit*564/700 + 1,
+			},
+			"lachesis": {
+				Cache:   scale(8 * opt.MiB),
+				Fdlimit: fdlimit*8/700 + 1,
+			},
+			"gossip-%d": {
+				Cache:   scale(64 * opt.MiB),
+				Fdlimit: fdlimit*64/700 + 1,
+			},
+			"lachesis-%d": {
+				Cache:   scale(64 * opt.MiB),
+				Fdlimit: fdlimit*64/700 + 1,
+			},
+			"": {
+				Cache:   64 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+func PblLegacyGenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(3072 * opt.MiB),
+				Fdlimit: fdlimit*3072 + 1,
+			},
+			"lachesis": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"gossip-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"lachesis-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"": {
+				Cache:   16 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}

--- a/integration/presets.go
+++ b/integration/presets.go
@@ -5,6 +5,8 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
+var DefaultDBsConfig = Ldb1DBsConfig
+
 /*
  * pbl-1 config
  */
@@ -26,7 +28,7 @@ func Pbl1RoutingConfig() RoutingConfig {
 			"lachesis": {
 				Type:  "pebble-fsh",
 				Name:  "main",
-				Table: "L",
+				Table: "C",
 			},
 			"gossip": {
 				Type: "pebble-fsh",
@@ -112,6 +114,95 @@ func Pbl1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 			"events": {
 				Cache:   scale(1 * opt.MiB),
 				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"epoch-%d": {
+				Cache:   scale(1 * opt.MiB),
+				Fdlimit: fdlimit*1/3072 + 1,
+			},
+			"": {
+				Cache:   16 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+/*
+ * ldb-1 config
+ */
+
+func Ldb1DBsConfig(scale func(uint64) uint64, fdlimit uint64) DBsConfig {
+	return DBsConfig{
+		Routing:      Ldb1RoutingConfig(),
+		RuntimeCache: Ldb1RuntimeDBsCacheConfig(scale, fdlimit),
+		GenesisCache: Ldb1GenesisDBsCacheConfig(scale, fdlimit),
+	}
+}
+
+func Ldb1RoutingConfig() RoutingConfig {
+	return RoutingConfig{
+		Table: map[string]multidb.Route{
+			"": {
+				Type: "leveldb-fsh",
+			},
+			"lachesis": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "C",
+			},
+			"gossip": {
+				Type: "leveldb-fsh",
+				Name: "main",
+			},
+			"evm": {
+				Type: "leveldb-fsh",
+				Name: "main",
+			},
+			"evm-logs": {
+				Type:  "leveldb-fsh",
+				Name:  "main",
+				Table: "L",
+			},
+			"gossip-%d": {
+				Type:  "leveldb-fsh",
+				Name:  "epoch-%d",
+				Table: "G",
+			},
+			"lachesis-%d": {
+				Type:   "leveldb-fsh",
+				Name:   "epoch-%d",
+				Table:  "L",
+				NoDrop: true,
+			},
+		},
+	}
+}
+
+func Ldb1RuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(625 * opt.MiB),
+				Fdlimit: fdlimit*625/700 + 1,
+			},
+			"epoch-%d": {
+				Cache:   scale(75 * opt.MiB),
+				Fdlimit: fdlimit*75/700 + 1,
+			},
+			"": {
+				Cache:   64 * opt.MiB,
+				Fdlimit: fdlimit/100 + 1,
+			},
+		},
+	}
+}
+
+func Ldb1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCacheConfig {
+	return DBsCacheConfig{
+		Table: map[string]DBCacheConfig{
+			"main": {
+				Cache:   scale(3072 * opt.MiB),
+				Fdlimit: fdlimit,
 			},
 			"epoch-%d": {
 				Cache:   scale(1 * opt.MiB),

--- a/integration/routing.go
+++ b/integration/routing.go
@@ -13,52 +13,6 @@ type RoutingConfig struct {
 	Table map[string]multidb.Route
 }
 
-func DefaultRoutingConfig() RoutingConfig {
-	return RoutingConfig{
-		Table: map[string]multidb.Route{
-			"": {
-				Type: "pebble-fsh",
-			},
-			"lachesis": {
-				Type:  "pebble-fsh",
-				Name:  "main",
-				Table: "L",
-			},
-			"gossip": {
-				Type: "pebble-fsh",
-				Name: "main",
-			},
-			"evm": {
-				Type: "pebble-fsh",
-				Name: "main",
-			},
-			"gossip/e": {
-				Type: "pebble-fsh",
-				Name: "events",
-			},
-			"evm/M": {
-				Type: "pebble-drc",
-				Name: "evm-data",
-			},
-			"evm-logs": {
-				Type: "pebble-fsh",
-				Name: "evm-logs",
-			},
-			"gossip-%d": {
-				Type:  "leveldb-fsh",
-				Name:  "epoch-%d",
-				Table: "G",
-			},
-			"lachesis-%d": {
-				Type:   "leveldb-fsh",
-				Name:   "epoch-%d",
-				Table:  "L",
-				NoDrop: true,
-			},
-		},
-	}
-}
-
 func MakeMultiProducer(rawProducers map[multidb.TypeName]kvdb.IterableDBProducer, scopedProducers map[multidb.TypeName]kvdb.FullDBProducer, cfg RoutingConfig) (kvdb.FullDBProducer, error) {
 	cachedProducers := make(map[multidb.TypeName]kvdb.FullDBProducer)
 	var flushID []byte


### PR DESCRIPTION
- add presets for DBs layout: ldb-1 (fastest leveldb-only layout), pbl-1 (fastest pebble/leveldb layout), legacy-ldb (legacy layout from 1.1.1 or earlier), legacy-pbl (layout from `1.1.1-rc.2-pebble`). ldb-1 is used by default instead of pbl-1.
- add `reformat` mode for multidb migration for instant migration with unaltered DBs layout

Migration options:
- Instant migration from a leveldb-based version: `--db.migration.mode reformat --db.preset legacy-ldb` 
- Instant migration from 1.1.1-rc.2-pebble: `--db.migration.mode reformat --db.preset legacy-pbl` 
- Migration with rebuilding DBs according to any configured layout: `--db.migration.mode rebuild`

Flag `--db.migration.mode` is required only if datadir isn't migrated.