### PR TITLE
Txtracing branch: Upgrade go-ethereum to v1.10.8-ftm-rc8 - fix issue #356

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,6 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc5
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc8
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc5 h1:3SMNRzp13oZZkOBwOtLqbXVKYGmxe+2Ak94snUd2yxU=
 github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc5/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
+github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc8 h1:A2XvonIgWN+pKdUvlpACCzdtuF7a41HG5ILaOMPi1cY=
+github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc8/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220103160934-6b4931c60582 h1:gDEbOynFwS7sp19XrtWnA1nEhSIXXO5DuAuT5h/nZgY=
 github.com/Fantom-foundation/lachesis-base v0.0.0-20220103160934-6b4931c60582/go.mod h1:E6+2LOvgADwSOv0U5YXhRJz4PlX8qJxvq8M93AOC1tM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Upgrade fantom's go-ethereum fork dependency to include fix of #356 (described in https://github.com/Fantom-foundation/go-ethereum/pull/37)