### PR TITLE
Refactor kvdb presets

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -132,7 +132,7 @@ const (
 	// DefaultCacheSize is calculated as memory consumption in a worst case scenario with default configuration
 	// Average memory consumption might be 3-5 times lower than the maximum
 	DefaultCacheSize  = 3600
-	ConstantCacheSize = 1024
+	ConstantCacheSize = 600
 )
 
 // These settings ensure that TOML keys use the same names as Go struct fields.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Fantom-foundation/go-opera
 go 1.14
 
 require (
-	github.com/Fantom-foundation/lachesis-base v0.0.0-20220811115347-2434192efadb
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20220904103856-4bb2a8448a22
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40 // indirect
 	github.com/cespare/cp v1.1.1
@@ -45,7 +45,5 @@ require (
 )
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7
-
-replace github.com/Fantom-foundation/lachesis-base => github.com/hadv/lachesis-base v0.0.0-20220802031837-77b6ebe3697f
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7 h1:wt1bhCeb3E0qzDV2iuv2qYlNDO/j8DFJfzVHSnevVOU=
 github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20220904103856-4bb2a8448a22 h1:wlB+I8x5mf1a3zlIuOTumy2ye/zglOIGcmTOfJ2bi8s=
+github.com/Fantom-foundation/lachesis-base v0.0.0-20220904103856-4bb2a8448a22/go.mod h1:CFMonaK1v/QHwpjLszuycFDgLXNazZqZxciwhKwXDVQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -285,8 +287,6 @@ github.com/graph-gophers/graphql-go v0.0.0-20201113091052-beb923fada29 h1:sezaKh
 github.com/graph-gophers/graphql-go v0.0.0-20201113091052-beb923fada29/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f h1:GQpcb9ywkaawJfZCFeIcrSWlsZFRTsig42e03dkzc+I=
 github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f/go.mod h1:Q5On640X2Z0YzKOijx9GVhUu/kvHnk9aKoWGMlRDMtc=
-github.com/hadv/lachesis-base v0.0.0-20220802031837-77b6ebe3697f h1:xwWrxjbSFAPhYAaYrStG0dIqLyRKMlH7w0c7x8uUGuM=
-github.com/hadv/lachesis-base v0.0.0-20220802031837-77b6ebe3697f/go.mod h1:CFMonaK1v/QHwpjLszuycFDgLXNazZqZxciwhKwXDVQ=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/integration/presets.go
+++ b/integration/presets.go
@@ -69,24 +69,24 @@ func Pbl1RuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"evm-data": {
-				Cache:   scale(242 * opt.MiB),
-				Fdlimit: fdlimit*242/700 + 1,
+				Cache:   scale(460 * opt.MiB),
+				Fdlimit: fdlimit*460/1400 + 1,
 			},
 			"evm-logs": {
-				Cache:   scale(110 * opt.MiB),
-				Fdlimit: fdlimit*110/700 + 1,
+				Cache:   scale(260 * opt.MiB),
+				Fdlimit: fdlimit*220/1400 + 1,
 			},
 			"main": {
-				Cache:   scale(186 * opt.MiB),
-				Fdlimit: fdlimit*186/700 + 1,
+				Cache:   scale(320 * opt.MiB),
+				Fdlimit: fdlimit*280/1400 + 1,
 			},
 			"events": {
-				Cache:   scale(87 * opt.MiB),
-				Fdlimit: fdlimit*87/700 + 1,
+				Cache:   scale(240 * opt.MiB),
+				Fdlimit: fdlimit*200/1400 + 1,
 			},
 			"epoch-%d": {
-				Cache:   scale(75 * opt.MiB),
-				Fdlimit: fdlimit*75/700 + 1,
+				Cache:   scale(100 * opt.MiB),
+				Fdlimit: fdlimit*100/1400 + 1,
 			},
 			"": {
 				Cache:   64 * opt.MiB,
@@ -100,24 +100,24 @@ func Pbl1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
 			},
 			"evm-data": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
 			},
 			"evm-logs": {
-				Cache:   scale(1024 * opt.MiB),
-				Fdlimit: fdlimit*1024/3072 + 1,
+				Cache:   scale(1000 * opt.MiB),
+				Fdlimit: fdlimit*1000/3000 + 1,
 			},
 			"events": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"epoch-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"": {
 				Cache:   16 * opt.MiB,
@@ -182,12 +182,12 @@ func Ldb1RuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(625 * opt.MiB),
-				Fdlimit: fdlimit*625/700 + 1,
+				Cache:   scale(900 * opt.MiB),
+				Fdlimit: fdlimit*900/1000 + 1,
 			},
 			"epoch-%d": {
-				Cache:   scale(75 * opt.MiB),
-				Fdlimit: fdlimit*75/700 + 1,
+				Cache:   scale(100 * opt.MiB),
+				Fdlimit: fdlimit*100/1000 + 1,
 			},
 			"": {
 				Cache:   64 * opt.MiB,
@@ -201,12 +201,12 @@ func Ldb1GenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) DBsCac
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(3072 * opt.MiB),
+				Cache:   scale(3000 * opt.MiB),
 				Fdlimit: fdlimit,
 			},
 			"epoch-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"": {
 				Cache:   16 * opt.MiB,
@@ -316,20 +316,20 @@ func LdbLegacyRuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) D
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(564 * opt.MiB),
-				Fdlimit: fdlimit*564/700 + 1,
+				Cache:   scale(850 * opt.MiB),
+				Fdlimit: fdlimit*850/1000 + 1,
 			},
 			"lachesis": {
-				Cache:   scale(8 * opt.MiB),
-				Fdlimit: fdlimit*8/700 + 1,
+				Cache:   scale(20 * opt.MiB),
+				Fdlimit: fdlimit*20/1000 + 1,
 			},
 			"gossip-%d": {
-				Cache:   scale(64 * opt.MiB),
-				Fdlimit: fdlimit*64/700 + 1,
+				Cache:   scale(50 * opt.MiB),
+				Fdlimit: fdlimit*50/1000 + 1,
 			},
 			"lachesis-%d": {
-				Cache:   scale(64 * opt.MiB),
-				Fdlimit: fdlimit*64/700 + 1,
+				Cache:   scale(80 * opt.MiB),
+				Fdlimit: fdlimit*80/1000 + 1,
 			},
 			"": {
 				Cache:   64 * opt.MiB,
@@ -343,20 +343,20 @@ func LdbLegacyGenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) D
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(3072 * opt.MiB),
-				Fdlimit: fdlimit*3072 + 1,
+				Cache:   scale(3000 * opt.MiB),
+				Fdlimit: fdlimit*3000 + 1,
 			},
 			"lachesis": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"gossip-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"lachesis-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"": {
 				Cache:   16 * opt.MiB,
@@ -466,20 +466,20 @@ func PblLegacyRuntimeDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) D
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(564 * opt.MiB),
-				Fdlimit: fdlimit*564/700 + 1,
+				Cache:   scale(950 * opt.MiB),
+				Fdlimit: fdlimit*950/1400 + 1,
 			},
 			"lachesis": {
-				Cache:   scale(8 * opt.MiB),
-				Fdlimit: fdlimit*8/700 + 1,
+				Cache:   scale(150 * opt.MiB),
+				Fdlimit: fdlimit*150/1400 + 1,
 			},
 			"gossip-%d": {
-				Cache:   scale(64 * opt.MiB),
-				Fdlimit: fdlimit*64/700 + 1,
+				Cache:   scale(150 * opt.MiB),
+				Fdlimit: fdlimit*150/1400 + 1,
 			},
 			"lachesis-%d": {
-				Cache:   scale(64 * opt.MiB),
-				Fdlimit: fdlimit*64/700 + 1,
+				Cache:   scale(150 * opt.MiB),
+				Fdlimit: fdlimit*150/1400 + 1,
 			},
 			"": {
 				Cache:   64 * opt.MiB,
@@ -493,20 +493,20 @@ func PblLegacyGenesisDBsCacheConfig(scale func(uint64) uint64, fdlimit uint64) D
 	return DBsCacheConfig{
 		Table: map[string]DBCacheConfig{
 			"main": {
-				Cache:   scale(3072 * opt.MiB),
-				Fdlimit: fdlimit*3072 + 1,
+				Cache:   scale(3000 * opt.MiB),
+				Fdlimit: fdlimit,
 			},
 			"lachesis": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"gossip-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"lachesis-%d": {
 				Cache:   scale(1 * opt.MiB),
-				Fdlimit: fdlimit*1/3072 + 1,
+				Fdlimit: fdlimit*1/3000 + 1,
 			},
 			"": {
 				Cache:   16 * opt.MiB,


### PR DESCRIPTION
- increase memory allocated for KVDB cache from 700MB to 1400MB for Pebble and 1000MB for LevelDB
- update lachesis-base version