### PR TITLE
Add parameter for setting time limit for RPC execution

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -90,6 +90,11 @@ var (
 		Usage: "Sets a cap on transaction fee (in FTM) that can be sent via the RPC APIs (0 = no cap)",
 		Value: gossip.DefaultConfig(cachescale.Identity).RPCTxFeeCap,
 	}
+	RPCGlobalTimeoutFlag = cli.DurationFlag{
+		Name:  "rpc.timeout",
+		Usage: "Time limit for RPC calls execution",
+		Value: gossip.DefaultConfig(cachescale.Identity).RPCTimeout,
+	}
 
 	SyncModeFlag = cli.StringFlag{
 		Name:  "syncmode",
@@ -313,6 +318,9 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) (gossip.Config, 
 	}
 	if ctx.GlobalIsSet(RPCGlobalTxFeeCapFlag.Name) {
 		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCapFlag.Name)
+	}
+	if ctx.GlobalIsSet(RPCGlobalTimeoutFlag.Name) {
+		cfg.RPCTimeout = ctx.GlobalDuration(RPCGlobalTimeoutFlag.Name)
 	}
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		if syncmode := ctx.GlobalString(SyncModeFlag.Name); syncmode != "full" && syncmode != "snap" {

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -154,6 +154,7 @@ func initFlags() {
 		utils.IPCPathFlag,
 		RPCGlobalGasCapFlag,
 		RPCGlobalTxFeeCapFlag,
+		RPCGlobalTimeoutFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,6 @@ require (
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum v1.10.8-ftm-rc7
+replace github.com/ethereum/go-ethereum => github.com/hkalina/go-ethereum v1.9.7-0.20220915185131-6c039374584a
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210103140116-f9104dfb626f

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,10 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hkalina/go-ethereum v1.9.7-0.20220915182718-0894be7182d3 h1:BIE2B5P37jwkJx4ACWDbR6oAbh3M/cbuhVGoYzddXE0=
+github.com/hkalina/go-ethereum v1.9.7-0.20220915182718-0894be7182d3/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
+github.com/hkalina/go-ethereum v1.9.7-0.20220915185131-6c039374584a h1:NiSyaXB7K1TQkTXeLNz+WaCdUmaS95c2l2Dv9dVmqoQ=
+github.com/hkalina/go-ethereum v1.9.7-0.20220915185131-6c039374584a/go.mod h1:IeQDjWCNBj/QiWIPosfF6/kRC6pHPNs7W7LfBzjj+P4=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -97,6 +97,9 @@ type (
 		// send-transction variants. The unit is ether.
 		RPCTxFeeCap float64 `toml:",omitempty"`
 
+		// RPCTimeout is a global time limit for RPC methods execution.
+		RPCTimeout time.Duration
+
 		// allows only for EIP155 transactions.
 		AllowUnprotectedTxs bool
 
@@ -212,6 +215,7 @@ func DefaultConfig(scale cachescale.Func) Config {
 
 		RPCGasCap:   50000000,
 		RPCTxFeeCap: 100, // 100 FTM
+		RPCTimeout:  60 * time.Second,
 	}
 	sessionCfg := cfg.Protocol.DagStreamLeecher.Session
 	cfg.Protocol.DagProcessor.EventsBufferLimit.Num = idx.Event(sessionCfg.ParallelChunksDownload)*

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -269,6 +269,8 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 		return nil, err
 	}
 
+	rpc.SetExecutionTimeLimit(config.RPCTimeout)
+
 	// create API backend
 	svc.EthAPI = &EthAPIBackend{false, svc, stateReader, txSigner, config.AllowUnprotectedTxs}
 


### PR DESCRIPTION
Allow to configure timeout for RPC method calls.

Related to https://github.com/Fantom-foundation/go-ethereum/pull/38

(go.mod to be rebased after the related go-ethereum change is merged/tagged)