### PR TITLE
Fix: Invalid unit name while exporting Genesis

### DIFF
--- a/cmd/opera/launcher/genesiscmd.go
+++ b/cmd/opera/launcher/genesiscmd.go
@@ -323,7 +323,7 @@ func exportGenesis(ctx *cli.Context) error {
 	if mode != "none" {
 		log.Info("Exporting EVM data", "from", fromBlock, "to", toBlock)
 		writer := newUnitWriter(plain)
-		err := writer.Start(header, genesisstore.BlocksSection, tmpPath)
+		err := writer.Start(header, genesisstore.EvmSection, tmpPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
While exporting genesis the unit names get Duplicated for the EVM section that causes an "Duplicate unit name" error while importing.