### PR TITLE
Fix of API eth_getLogs

### DIFF
--- a/topicsdb/search_parallel.go
+++ b/topicsdb/search_parallel.go
@@ -37,6 +37,7 @@ func (tt *Index) searchParallel(ctx context.Context, pattern [][]common.Hash, bl
 				return
 			}
 			if rec.topicsCount < uint8(len(pattern)-1) {
+				gonext = true
 				return
 			}
 


### PR DESCRIPTION
Fix of topicsdb search which serves eth_getLogs API method.
TestIndexSearchShortCircuits() to cover the cases.

We should also apply this hotfix to release/1.1.2-rc.1 and later (after #336).

The bug leads to eth_getLogs stops logs search after found a log matching the pattern part but having less topics count then full pattern needs. So not all the search results was complete.