### PR TITLE
Fix non-opera ENR in launcher.TestConfigFile test

### DIFF
--- a/cmd/opera/launcher/config_custom_test.go
+++ b/cmd/opera/launcher/config_custom_test.go
@@ -44,7 +44,7 @@ func TestConfigFile(t *testing.T) {
 		"Empty":   {},
 		"Default": asDefault,
 		"UserDefined": {enode.MustParse(
-			"enr:-HW4QIEFxJwyZzPQJPE2DbQpEu7FM1Gv99VqJ3CbLb22fm9_V9cfdZdSBpZCyrEb5UfMeC6k9WT0iaaeAjRcuzCfr4yAgmlkgnY0iXNlY3AyNTZrMaECps0D9hhmXEN5BMgVVe0xT5mpYU9zv4YxCdTApmfP-l0",
+			"enr:-J-4QJmPmUmu14Pn7gUtRNfKHaWFQpcX6fgqrNheDSWUN6giKtix8Lh6EKfymTdXCI5HKGmyl0C5eOKvem5xdC70hLEBgmlkgnY0gmlwhMCoAQKFb3BlcmHHxoQHxfIKgIlzZWNwMjU2azGhAjYQROWoAXivxhtYYBXGXzQrBTAHGJT9XPP69oUzDDWwhHNuYXDAg3RjcIITuoN1ZHCCE7o",
 		)},
 	} {
 		t.Run(name+"BootstrapNodes", func(t *testing.T) {


### PR DESCRIPTION
After upgrading Fantom/go-ethereum to the latest dev version, the launcher.TestConfigFile starts to fail, because of new validation introduced in https://github.com/Fantom-foundation/go-ethereum/pull/39:
```
--- FAIL: TestConfigFile (0.00s)
panic: invalid node: invalid opera node; missing ENR key "opera" [recovered]
  panic: invalid node: invalid opera node; missing ENR key "opera"
goroutine 176 [running]:
testing.tRunner.func1.2({0x14e12c0, 0xc000122960})
  /usr/local/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
  /usr/local/go/src/testing/testing.go:1399 +0x39f
panic({0x14e12c0, 0xc000122960})
  /usr/local/go/src/runtime/panic.go:884 +0x212
github.com/ethereum/go-ethereum/p2p/enode.MustParse({0x17cf89a?, 0xc00085eba8?})
  /opt/TeamCity/go/pkg/mod/github.com/!fantom-foundation/go-ethereum@v1.10.8-ftm-rc8.0.20221115161923-d862fc5364f4/p2p/enode/node.go:58 +0x7a
github.com/Fantom-foundation/go-opera/cmd/opera/launcher.TestConfigFile(0xc000710340?)
  /opt/TeamCity/buildAgent/work/9326af52a9759e7b/cmd/opera/launcher/config_custom_test.go:46 +0x51d
testing.tRunner(0xc000710340, 0x188dc20)
  /usr/local/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
  /usr/local/go/src/testing/testing.go:1493 +0x35f
```
This fixes the test - replaces the ENR by one with the required "opera" parameter (use fake ip 192.168.1.2 and only for this purpose generated pubkey).