### PR TITLE
gossip/evmstore: remove unmeaning warning log

### DIFF
--- a/gossip/evmstore/store.go
+++ b/gossip/evmstore/store.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
@@ -262,8 +261,8 @@ func (s *Store) Cap() {
 		nodes, imgs = triedb.Size()
 		limit       = common.StorageSize(s.cfg.Cache.TrieDirtyLimit)
 	)
+	// If we exceeded our memory allowance, flush matured singleton nodes to disk
 	if nodes > limit+ethdb.IdealBatchSize || imgs > 4*1024*1024 {
-		log.Warn("If we exceeded our memory allowance, flush matured singleton nodes to disk")
 		triedb.Cap(limit)
 	}
 }


### PR DESCRIPTION
It's not much meaning to output warning log due to it's normal behavior of pruning. Moving it into comment code for reference only.