### PR TITLE
Tx traces mandatory field also when they have no value

### DIFF
--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
@@ -76,14 +77,15 @@ func (tr *TraceStructLogger) CaptureStart(env *vm.EVM, from common.Address, to c
 		txAction = NewAddressAction(tr.from, gas, tr.inputData, nil, hexutil.Big(tr.value), nil)
 		if newAddress != nil {
 			blockTrace.Result.Address = newAddress
-			blockTrace.Result.Code = hexutil.Bytes(tr.output)
+			code := hexutil.Bytes(tr.output)
+			blockTrace.Result.Code = &code
 		}
 	} else {
 		txAction = NewAddressAction(tr.from, gas, tr.inputData, tr.to, hexutil.Big(tr.value), &callType)
 		out := hexutil.Bytes(tr.output)
 		blockTrace.Result.Output = &out
 	}
-	blockTrace.Action = *txAction
+	blockTrace.Action = txAction
 
 	// Add root object into Tracer
 	txTrace.AddTrace(blockTrace)
@@ -144,7 +146,7 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 		trace := NewActionTraceFromTrace(fromTrace, CREATE, tr.traceAddress)
 		from := scope.Contract.Address()
 		traceAction := NewAddressAction(&from, gas, input, nil, fromTrace.Action.Value, nil)
-		trace.Action = *traceAction
+		trace.Action = traceAction
 		trace.Result.GasUsed = hexutil.Uint64(gas)
 		fromTrace.childTraces = append(fromTrace.childTraces, trace)
 		tr.rootTrace.Stack = append(tr.rootTrace.Stack, trace)
@@ -183,7 +185,7 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 		addr := common.BytesToAddress(stackPosFromEnd(scope.Stack.Data(), 1).Bytes())
 		callType := strings.ToLower(op.String())
 		traceAction := NewAddressAction(&from, gas, input, &addr, hexutil.Big(*value), &callType)
-		trace.Action = *traceAction
+		trace.Action = traceAction
 		fromTrace.childTraces = append(fromTrace.childTraces, trace)
 		trace.Result.RetOffset = retOffset
 		trace.Result.RetSize = retSize
@@ -206,7 +208,8 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 				}
 
 				if lastState(tr.state).create {
-					result.Code = data
+					code := hexutil.Bytes(data)
+					result.Code = &code
 				} else {
 					result.GasUsed = hexutil.Uint64(gas)
 					out := hexutil.Bytes(data)
@@ -234,7 +237,7 @@ func (tr *TraceStructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, 
 		traceAction.RefundAddress = &refundAddress
 		// Add `balance` field for convenient usage
 		traceAction.Balance = &traceAction.Value
-		trace.Action = *traceAction
+		trace.Action = traceAction
 		fromTrace.childTraces = append(fromTrace.childTraces, trace)
 	}
 }
@@ -258,17 +261,18 @@ func (*TraceStructLogger) CaptureEnter(typ vm.OpCode, from common.Address, to co
 
 // CaptureExit is called when returning from an inner call
 func (tr *TraceStructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {
-        // When going back from inner call
-        result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
-        if result != nil {
-                result.GasUsed = hexutil.Uint64(gasUsed)
-        }
+	// When going back from inner call
+	result := tr.rootTrace.Stack[len(tr.rootTrace.Stack)-1].Result
+	if result != nil {
+		result.GasUsed = hexutil.Uint64(gasUsed)
+		out := hexutil.Bytes(output)
+		result.Output = &out
+	}
 }
 
 // CaptureFault implements the Tracer interface to trace an execution fault
 // while running an opcode.
 func (tr *TraceStructLogger) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, scope *vm.ScopeContext, depth int, err error) {
-	return
 }
 
 // Reset function to be able to reuse logger
@@ -340,8 +344,7 @@ func (tr *TraceStructLogger) ProcessTx() {
 func (tr *TraceStructLogger) SaveTrace() {
 	if tr.rootTrace == nil {
 		tr.rootTrace = &CallTrace{}
-		tr.rootTrace.AddTrace(GetErrorTrace(tr.blockHash, tr.blockNumber, tr.to, tr.tx, tr.gasUsed, tr.err))
-
+		tr.rootTrace.AddTrace(GetErrorTraceFromLogger(tr))
 	}
 
 	//if tr.store != nil && tr.rootTrace != nil {
@@ -442,7 +445,7 @@ const (
 // ActionTrace represents single interaction with blockchain
 type ActionTrace struct {
 	childTraces         []*ActionTrace     `json:"-"`
-	Action              AddressAction      `json:"action"`
+	Action              *AddressAction     `json:"action"`
 	BlockHash           common.Hash        `json:"blockHash"`
 	BlockNumber         big.Int            `json:"blockNumber"`
 	Result              *TraceActionResult `json:"result,omitempty"`
@@ -463,10 +466,11 @@ func NewAddressAction(from *common.Address, gas uint64, data []byte, to *common.
 		Value:    value,
 		CallType: callType,
 	}
+	inputHex := hexutil.Bytes(common.CopyBytes(data))
 	if callType == nil {
-		action.Init = hexutil.Bytes(data)
+		action.Init = &inputHex
 	} else {
-		action.Input = hexutil.Bytes(data)
+		action.Input = &inputHex
 	}
 	return &action
 }
@@ -479,8 +483,8 @@ type AddressAction struct {
 	To            *common.Address `json:"to,omitempty"`
 	Value         hexutil.Big     `json:"value"`
 	Gas           hexutil.Uint64  `json:"gas"`
-	Init          hexutil.Bytes   `json:"init,omitempty"`
-	Input         hexutil.Bytes   `json:"input,omitempty"`
+	Init          *hexutil.Bytes  `json:"init,omitempty"`
+	Input         *hexutil.Bytes  `json:"input,omitempty"`
 	Address       *common.Address `json:"address,omitempty"`
 	RefundAddress *common.Address `json:"refund_address,omitempty"`
 	Balance       *hexutil.Big    `json:"balance,omitempty"`
@@ -491,7 +495,7 @@ type AddressAction struct {
 type TraceActionResult struct {
 	GasUsed   hexutil.Uint64  `json:"gasUsed"`
 	Output    *hexutil.Bytes  `json:"output,omitempty"`
-	Code      hexutil.Bytes   `json:"code,omitempty"`
+	Code      *hexutil.Bytes  `json:"code,omitempty"`
 	Address   *common.Address `json:"address,omitempty"`
 	RetOffset uint64          `json:"-"`
 	RetSize   uint64          `json:"-"`
@@ -565,19 +569,52 @@ func (callTrace *CallTrace) processTrace(trace *ActionTrace) {
 }
 
 // GetErrorTrace constructs filled error trace
-func GetErrorTrace(blockHash common.Hash, blockNumber big.Int, to *common.Address, txHash common.Hash, index uint64, err error) *ActionTrace {
+func GetErrorTrace(blockHash common.Hash, blockNumber big.Int, from *common.Address, to *common.Address, txHash common.Hash, index uint64, err error) *ActionTrace {
+	return createErrorTrace(blockHash, blockNumber, from, to, txHash, 0, []byte{}, hexutil.Big{}, index, err)
+}
+
+// GetErrorTrace constructs filled error trace
+func GetErrorTraceFromLogger(tr *TraceStructLogger) *ActionTrace {
+	if tr == nil {
+		return nil
+	} else {
+		return createErrorTrace(tr.blockHash, tr.blockNumber, tr.from, tr.to, tr.tx, tr.gasUsed, tr.inputData, hexutil.Big(tr.value), uint64(tr.txIndex), tr.err)
+	}
+}
+
+// GetErrorTrace constructs filled error trace
+func GetErrorTraceFromMsg(msg *types.Message, blockHash common.Hash, blockNumber big.Int, txHash common.Hash, index uint64, err error) *ActionTrace {
+	if msg == nil {
+		return createErrorTrace(blockHash, blockNumber, nil, &common.Address{}, txHash, 0, []byte{}, hexutil.Big{}, index, err)
+	} else {
+		from := msg.From()
+		return createErrorTrace(blockHash, blockNumber, &from, msg.To(), txHash, msg.Gas(), msg.Data(), hexutil.Big(*msg.Value()), index, err)
+	}
+}
+
+// createErrorTrace constructs filled error trace
+func createErrorTrace(blockHash common.Hash, blockNumber big.Int,
+	from *common.Address, to *common.Address,
+	txHash common.Hash, gas uint64, input []byte,
+	value hexutil.Big,
+	index uint64, err error) *ActionTrace {
 
 	var blockTrace *ActionTrace
 	var txAction *AddressAction
 
-	if to != nil {
-		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, "empty")
-		txAction = NewAddressAction(&common.Address{}, 0, []byte{}, to, hexutil.Big{}, nil)
-	} else {
-		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, "empty")
-		txAction = NewAddressAction(&common.Address{}, 0, []byte{}, nil, hexutil.Big{}, nil)
+	if from == nil {
+		from = &common.Address{}
 	}
-	blockTrace.Action = *txAction
+
+	callType := CALL
+	if to != nil {
+		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, CALL)
+		txAction = NewAddressAction(from, gas, input, to, hexutil.Big{}, &callType)
+	} else {
+		blockTrace = NewActionTrace(blockHash, blockNumber, txHash, index, CREATE)
+		txAction = NewAddressAction(from, gas, input, nil, hexutil.Big{}, nil)
+	}
+	blockTrace.Action = txAction
 	blockTrace.Result = nil
 	if err != nil {
 		blockTrace.Error = err.Error()


### PR DESCRIPTION
With new Rust implementation of Web3 parser, there is a need of having mandatory fields in transaction trace even when they dont have any value. In that case, they will have "0x" value for hex results.
This PR also adds parallel procesing of the trace_filter function which process more blocks and in case, there is no need for order of traces, then blocks are processed in parallel.