### PR TITLE
Close pending iterators of released snapshots

### DIFF
--- a/gossip/store.go
+++ b/gossip/store.go
@@ -17,10 +17,10 @@ import (
 	"github.com/Fantom-foundation/go-opera/gossip/evmstore"
 	"github.com/Fantom-foundation/go-opera/logger"
 	"github.com/Fantom-foundation/go-opera/utils/adapters/snap2kvdb"
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/switchable"
 	"github.com/Fantom-foundation/go-opera/utils/eventid"
 	"github.com/Fantom-foundation/go-opera/utils/randat"
 	"github.com/Fantom-foundation/go-opera/utils/rlpstore"
-	"github.com/Fantom-foundation/go-opera/utils/switchable"
 )
 
 // Store is a node persistent storage working over physical key-value database.

--- a/utils/dbutil/itergc/iterator_gc.go
+++ b/utils/dbutil/itergc/iterator_gc.go
@@ -1,0 +1,64 @@
+package itergc
+
+import (
+	"sync"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+)
+
+type Snapshot struct {
+	kvdb.Snapshot
+	nextID uint64
+	iters  map[uint64]kvdb.Iterator
+	mu     sync.Locker
+}
+
+type Iterator struct {
+	kvdb.Iterator
+	mu    sync.Locker
+	id    uint64
+	iters map[uint64]kvdb.Iterator
+}
+
+// Wrap snapshot to automatically close all pending iterators upon snapshot release
+func Wrap(snapshot kvdb.Snapshot, mu sync.Locker) *Snapshot {
+	return &Snapshot{
+		Snapshot: snapshot,
+		iters:    make(map[uint64]kvdb.Iterator),
+		mu:       mu,
+	}
+}
+
+func (s *Snapshot) NewIterator(prefix []byte, start []byte) kvdb.Iterator {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	it := s.Snapshot.NewIterator(prefix, start)
+	id := s.nextID
+	s.iters[id] = it
+	s.nextID++
+
+	return &Iterator{
+		Iterator: it,
+		mu:       s.mu,
+		id:       id,
+		iters:    s.iters,
+	}
+}
+
+func (s *Iterator) Release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Iterator.Release()
+	delete(s.iters, s.id)
+}
+
+func (s *Snapshot) Release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// release all pending iterators
+	for _, it := range s.iters {
+		it.Release()
+	}
+	s.iters = nil
+	s.Snapshot.Release()
+}

--- a/utils/dbutil/switchable/snapshot_test.go
+++ b/utils/dbutil/switchable/snapshot_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/dbcounter"
 )
 
 func decodePair(b []byte) (uint32, uint32) {
@@ -62,7 +64,7 @@ func TestSnapshot_SwitchTo(t *testing.T) {
 	const duration = time.Millisecond * 400
 
 	// fill DB with data
-	memdb := memorydb.New()
+	memdb := dbcounter.WrapStore(memorydb.New(), "", false)
 	for i := uint32(0); i < prefixes; i++ {
 		for j := uint32(0); j < keys; j++ {
 			key := append(bigendian.Uint32ToBytes(i), bigendian.Uint32ToBytes(j)...)
@@ -145,4 +147,6 @@ func TestSnapshot_SwitchTo(t *testing.T) {
 	time.Sleep(duration)
 	atomic.StoreUint32(&stop, 1)
 	wg.Wait()
+	switchable.Release()
+	require.NoError(memdb.Close())
 }


### PR DESCRIPTION
- explicitly close all snapshot iterators on snapshot release. Not closing iterators doesn't appear to cause a memory or a space leak on LevelDB and Pebble - this PR is meant to avoid any future issue with other types of DBs
- fix race condition in swtichable module, which might cause opening extra iterator on snapshot switching (doesn't seem to matter on LevelDB and Pebble)