### PR TITLE
Memorize DB preset

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -386,34 +386,34 @@ func setDBConfigStr(cfg integration.DBsConfig, cacheRatio cachescale.Func, prese
 		utils.Fatalf("--%s must be 'pbl-1', 'ldb-1', 'legacy-pbl' or 'legacy-ldb'", DBPresetFlag.Name)
 	}
 	// sanity check
-	if preset != reversePresetName(cfg) {
+	if preset != reversePresetName(cfg.Routing) {
 		log.Error("Preset name cannot be reversed")
 	}
 	return cfg
 }
 
-func reversePresetName(cfg integration.DBsConfig) string {
-	pbl1 := integration.Pbl1DBsConfig(cachescale.Identity.U64, uint64(utils.MakeDatabaseHandles()))
-	ldb1 := integration.Ldb1DBsConfig(cachescale.Identity.U64, uint64(utils.MakeDatabaseHandles()))
-	ldbLegacy := integration.LdbLegacyDBsConfig(cachescale.Identity.U64, uint64(utils.MakeDatabaseHandles()))
-	pblLegacy := integration.PblLegacyDBsConfig(cachescale.Identity.U64, uint64(utils.MakeDatabaseHandles()))
-	if cfg.Routing.Equal(pbl1.Routing) {
+func reversePresetName(cfg integration.RoutingConfig) string {
+	pbl1 := integration.Pbl1RoutingConfig()
+	ldb1 := integration.Ldb1RoutingConfig()
+	ldbLegacy := integration.LdbLegacyRoutingConfig()
+	pblLegacy := integration.PblLegacyRoutingConfig()
+	if cfg.Equal(pbl1) {
 		return "pbl-1"
 	}
-	if cfg.Routing.Equal(ldb1.Routing) {
+	if cfg.Equal(ldb1) {
 		return "ldb-1"
 	}
-	if cfg.Routing.Equal(ldbLegacy.Routing) {
+	if cfg.Equal(ldbLegacy) {
 		return "legacy-ldb"
 	}
-	if cfg.Routing.Equal(pblLegacy.Routing) {
+	if cfg.Equal(pblLegacy) {
 		return "legacy-pbl"
 	}
 	return ""
 }
 
 func memorizeDBPreset(cfg *config) {
-	preset := reversePresetName(cfg.DBs)
+	preset := reversePresetName(cfg.DBs.Routing)
 	pPath := path.Join(cfg.Node.DataDir, "chaindata", "preset")
 	if len(preset) != 0 {
 		futils.FilePut(pPath, []byte(preset), true)

--- a/cmd/opera/launcher/db-transform.go
+++ b/cmd/opera/launcher/db-transform.go
@@ -114,6 +114,7 @@ func dbTransform(ctx *cli.Context) error {
 		}
 	}
 
+	memorizeDBPreset(cfg)
 	log.Info("DB transformation is complete")
 
 	return nil

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -300,6 +300,7 @@ func makeNode(ctx *cli.Context, cfg *config, genesisStore *genesisstore.Store) (
 		_ = genesisStore.Close()
 	}
 	metrics.SetDataDir(cfg.Node.DataDir)
+	memorizeDBPreset(cfg)
 
 	// substitute default bootnodes if requested
 	networkName := ""

--- a/gossip/emitter/prev_action_files.go
+++ b/gossip/emitter/prev_action_files.go
@@ -2,29 +2,15 @@ package emitter
 
 import (
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/Fantom-foundation/go-opera/utils"
 )
 
-func openPrevActionFile(path string, isSyncMode bool) *os.File {
-	const dirPerm = 0700
-	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
-		log.Crit("Failed to create open event file", "file", path, "err", err)
-	}
-	sync := 0
-	if isSyncMode {
-		sync = os.O_SYNC
-	}
-	fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|sync, 0666)
-	if err != nil {
-		log.Crit("Failed to open event file", "file", path, "err", err)
-	}
-	return fh
-}
+var openPrevActionFile = utils.OpenFile
 
 func (em *Emitter) writeLastEmittedEventID(id hash.Event) {
 	if em.emittedEventFile == nil {

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -192,18 +192,6 @@ func translateGossipPrefix(p byte) byte {
 	return p
 }
 
-func equalRoutingConfig(a, b RoutingConfig) bool {
-	if len(a.Table) != len(b.Table) {
-		return false
-	}
-	for k, v := range a.Table {
-		if b.Table[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
 func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode string, layout RoutingConfig) error {
 	{ // didn't erase the brackets to avoid massive code changes
 		// migrate DB layout
@@ -308,7 +296,7 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 			}
 		case "reformat":
 			if oldDBsType == "ldb" {
-				if !equalRoutingConfig(layout, LdbLegacyRoutingConfig()) {
+				if !layout.Equal(LdbLegacyRoutingConfig()) {
 					return errors.New("reformatting DBs: missing --db.preset=legacy-ldb flag")
 				}
 				err = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "leveldb-fsh", "main"))
@@ -324,7 +312,7 @@ func migrateLegacyDBs(chaindataDir string, dbs kvdb.FlushableDBProducer, mode st
 					}
 				}
 			} else {
-				if !equalRoutingConfig(layout, PblLegacyRoutingConfig()) {
+				if !layout.Equal(PblLegacyRoutingConfig()) {
 					return errors.New("reformatting DBs: missing --db.preset=legacy-pbl flag")
 				}
 				err = os.Rename(path.Join(chaindataDir, "gossip"), path.Join(chaindataDir, "pebble-fsh", "main"))

--- a/integration/presets.go
+++ b/integration/presets.go
@@ -6,6 +6,7 @@ import (
 )
 
 var DefaultDBsConfig = Ldb1DBsConfig
+var DefaultDBsConfigName = "ldb-1"
 
 /*
  * pbl-1 config

--- a/integration/routing.go
+++ b/integration/routing.go
@@ -13,6 +13,18 @@ type RoutingConfig struct {
 	Table map[string]multidb.Route
 }
 
+func (a RoutingConfig) Equal(b RoutingConfig) bool {
+	if len(a.Table) != len(b.Table) {
+		return false
+	}
+	for k, v := range a.Table {
+		if b.Table[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 func MakeMultiProducer(rawProducers map[multidb.TypeName]kvdb.IterableDBProducer, scopedProducers map[multidb.TypeName]kvdb.FullDBProducer, cfg RoutingConfig) (kvdb.FullDBProducer, error) {
 	cachedProducers := make(map[multidb.TypeName]kvdb.FullDBProducer)
 	var flushID []byte

--- a/integration/status.go
+++ b/integration/status.go
@@ -3,11 +3,12 @@ package integration
 import (
 	"os"
 	"path"
+
+	"github.com/Fantom-foundation/go-opera/utils"
 )
 
 func isInterrupted(chaindataDir string) bool {
-	_, err := os.Stat(path.Join(chaindataDir, "unfinished"))
-	return err == nil
+	return utils.FileExists(path.Join(chaindataDir, "unfinished"))
 }
 
 func setGenesisProcessing(chaindataDir string) {

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func OpenFile(path string, isSyncMode bool) *os.File {
+	const dirPerm = 0700
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		log.Crit("Failed to create file dir", "file", path, "err", err)
+	}
+	sync := 0
+	if isSyncMode {
+		sync = os.O_SYNC
+	}
+	fh, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|sync, 0666)
+	if err != nil {
+		log.Crit("Failed to open file", "file", path, "err", err)
+	}
+	return fh
+}
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func FilePut(path string, content []byte, isSyncMode bool) {
+	fh := OpenFile(path, isSyncMode)
+	defer fh.Close()
+	if err := fh.Truncate(0); err != nil {
+		log.Crit("Failed to truncate file", "file", path, "err", err)
+	}
+	if _, err := fh.Write(content); err != nil {
+		log.Crit("Failed to write to file", "file", path, "err", err)
+	}
+}
+
+func FileGet(path string) []byte {
+	if !FileExists(path) {
+		return nil
+	}
+	fh, err := os.Open(path)
+	if err != nil {
+		log.Crit("Failed to open file", "file", path, "err", err)
+	}
+	defer fh.Close()
+	res, _ := ioutil.ReadAll(fh)
+	return res
+}


### PR DESCRIPTION
- update logging for `db heal`
- memorize previous datadir DB preset as default

Before:
```
opera --db.preset pbl-1 --datadir P
opera --db.preset pbl-1 --datadir P
opera --db.preset pbl-1 --datadir P db compact
```
After:
```
opera --db.preset pbl-1 --datadir P
opera --datadir P
opera --datadir P db compact
```