### PR TITLE
Transaction tracing evm rpc timeout from parameter

### DIFF
--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -403,11 +403,6 @@ func (s *PublicTxTraceAPI) Filter(ctx context.Context, args FilterArgs) (*[]txtr
 		log.Info("Executing trace_filter call finished", data...)
 	}(time.Now())
 
-	// TODO put timeout to server configuration
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 100*time.Second)
-	defer cancel()
-
 	// process arguments
 	var (
 		fromBlock, toBlock rpc.BlockNumber

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -68,8 +68,10 @@ func (s *PublicTxTraceAPI) traceTx(
 
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.
-	// TODO add time into the server configuration
-	var timeout time.Duration = 3 * time.Second
+	var timeout time.Duration = 5 * time.Second
+	if s.b.RPCEVMTimeout() > 0 {
+		timeout = s.b.RPCEVMTimeout()
+	}
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 


### PR DESCRIPTION
As `RPCTimeout` and `RPCEVMTimeout` parameters are now included in the config of go-opera, this PR is using these parameters for transaction replay mechanism for generating transaction traces.