### PR TITLE
add flag to init account state from genesis json file for fakenet

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -210,7 +212,24 @@ func mayGetGenesisStore(ctx *cli.Context) *genesisstore.Store {
 		if err != nil {
 			log.Crit("Invalid flag", "flag", FakeNetFlag.Name, "err", err)
 		}
-		return makefakegenesis.FakeGenesisStore(num, futils.ToFtm(1000000000), futils.ToFtm(5000000))
+		if ctx.GlobalIsSet(InitGenesisFlag.Name) {
+			genesisPath := ctx.GlobalString(InitGenesisFlag.Name)
+			if len(genesisPath) == 0 {
+				utils.Fatalf("invalid path to genesis file")
+			}
+			file, err := os.Open(genesisPath)
+			if err != nil {
+				utils.Fatalf("Failed to read genesis file: %v", err)
+			}
+			defer file.Close()
+
+			genesis := new(core.Genesis)
+			if err := json.NewDecoder(file).Decode(genesis); err != nil {
+				utils.Fatalf("invalid genesis file: %v", err)
+			}
+			return makefakegenesis.FakeGenesisStore(num, futils.ToFtm(1000000000), futils.ToFtm(5000000), genesis)
+		}
+		return makefakegenesis.FakeGenesisStore(num, futils.ToFtm(1000000000), futils.ToFtm(5000000), nil)
 	case ctx.GlobalIsSet(GenesisFlag.Name):
 		genesisPath := ctx.GlobalString(GenesisFlag.Name)
 

--- a/cmd/opera/launcher/fake.go
+++ b/cmd/opera/launcher/fake.go
@@ -18,6 +18,11 @@ var FakeNetFlag = cli.StringFlag{
 	Usage: "'n/N' - sets coinbase as fake n-th key from genesis of N validators.",
 }
 
+var InitGenesisFlag = cli.StringFlag{
+	Name:  "init",
+	Usage: "path to genesis json file to allocate account/contract genesis state for testing purpose on fakenet",
+}
+
 func getFakeValidatorKey(ctx *cli.Context) *ecdsa.PrivateKey {
 	id, _, err := parseFakeGen(ctx.GlobalString(FakeNetFlag.Name))
 	if err != nil || id == 0 {

--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -65,6 +65,7 @@ func initFlags() {
 	// Flags for testing purpose.
 	testFlags = []cli.Flag{
 		FakeNetFlag,
+		InitGenesisFlag,
 	}
 
 	// Flags that configure the node.

--- a/docker/Dockerfile.opera
+++ b/docker/Dockerfile.opera
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM golang:1.17-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -135,7 +135,7 @@ func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator) *testEnv {
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Blocks.MaxEmptyBlockSkipPeriod = 0
 
-	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(validatorsNum, utils.ToFtm(genesisBalance), utils.ToFtm(genesisStake), rules, firstEpoch, 2)
+	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(validatorsNum, utils.ToFtm(genesisBalance), utils.ToFtm(genesisStake), rules, firstEpoch, 2, nil)
 	genesis := genStore.Genesis()
 
 	store := NewMemStore()

--- a/integration/bench_db_flush_test.go
+++ b/integration/bench_db_flush_test.go
@@ -21,7 +21,7 @@ import (
 func BenchmarkFlushDBs(b *testing.B) {
 	dir := tmpDir("flush_bench")
 	defer os.RemoveAll(dir)
-	genStore := makefakegenesis.FakeGenesisStore(1, utils.ToFtm(1), utils.ToFtm(1))
+	genStore := makefakegenesis.FakeGenesisStore(1, utils.ToFtm(1), utils.ToFtm(1), nil)
 	g := genStore.Genesis()
 	_, _, store, s2, _, closeDBs := MakeEngine(dir, &g, Configs{
 		Opera:         gossip.DefaultConfig(cachescale.Identity),

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 
@@ -43,20 +44,31 @@ func FakeKey(n idx.ValidatorID) *ecdsa.PrivateKey {
 	return evmcore.FakeKey(int(n))
 }
 
-func FakeGenesisStore(num idx.Validator, balance, stake *big.Int) *genesisstore.Store {
-	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules())
+func FakeGenesisStore(num idx.Validator, balance, stake *big.Int, genesis *core.Genesis) *genesisstore.Store {
+	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(), genesis)
 }
 
-func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *big.Int, rules opera.Rules) *genesisstore.Store {
-	return FakeGenesisStoreWithRulesAndStart(num, balance, stake, rules, 2, 1)
+func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *big.Int, rules opera.Rules, genesis *core.Genesis) *genesisstore.Store {
+	return FakeGenesisStoreWithRulesAndStart(num, balance, stake, rules, 2, 1, genesis)
 }
 
-func FakeGenesisStoreWithRulesAndStart(num idx.Validator, balance, stake *big.Int, rules opera.Rules, epoch idx.Epoch, block idx.Block) *genesisstore.Store {
+func FakeGenesisStoreWithRulesAndStart(num idx.Validator, balance, stake *big.Int, rules opera.Rules, epoch idx.Epoch, block idx.Block, g *core.Genesis) *genesisstore.Store {
 	builder := makegenesis.NewGenesisBuilder(memorydb.NewProducer(""))
 
-	validators := GetFakeValidators(num)
+	// init genesis alloc accounts if any
+	if g != nil {
+		for addr, account := range g.Alloc {
+			builder.AddBalance(addr, account.Balance)
+			builder.SetCode(addr, account.Code)
+			builder.SetNonce(addr, account.Nonce)
+			for key, value := range account.Storage {
+				builder.SetStorage(addr, key, value)
+			}
+		}
+	}
 
 	// add balances to validators
+	validators := GetFakeValidators(num)
 	var delegations []drivercall.Delegation
 	for _, val := range validators {
 		builder.AddBalance(val.Address, balance)


### PR DESCRIPTION
to more convenient for running testing by using fakenet, we introduce the `--init genesis.json` flag to be able allocate some account and pre-compiled contract for testing.

the genesis json file example

```
{
  "alloc": {
    "cf49fda3be353c69b41ed96333cd24302da4556f": {
      "balance": "0x123450000000000000000"
    },
    "0161e041aad467a890839d5b08b138c1e6373072": {
      "balance": "0x123450000000000000000"
    },
    "87da6a8c6e9eff15d703fc2773e32f6af8dbe301": {
      "balance": "0x123450000000000000000"
    },
    "b97de4b8c857e4f6bc354f226dc3249aaee49209": {
      "balance": "0x123450000000000000000"
    },
    "c5065c9eeebe6df2c2284d046bfc906501846c51": {
      "balance": "0x123450000000000000000"
    },
    "0000000000000000000000000000000000000314": {
      "balance": "0x0",
      "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a223e05d1461006a578063abd1a0cf1461008d578063abfced1d146100d4578063e05c914a14610110578063e6768b451461014c575b610000565b346100005761007761019d565b6040518082815260200191505060405180910390f35b34610000576100be600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506101a3565b6040518082815260200191505060405180910390f35b346100005761010e600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506101ed565b005b346100005761014a600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610236565b005b346100005761017960048080359060200190919080359060200190919080359060200190919050506103c4565b60405180848152602001838152602001828152602001935050505060405180910390f35b60005481565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b919050565b80600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055505b5050565b7f6031a8d62d7c95988fa262657cd92107d90ed96e08d8f867d32f26edfe85502260405180905060405180910390a17f47e2689743f14e97f7dcfa5eec10ba1dff02f83b3d1d4b9c07b206cbbda66450826040518082815260200191505060405180910390a1817fa48a6b249a5084126c3da369fbc9b16827ead8cb5cdc094b717d3f1dcd995e2960405180905060405180910390a27f7890603b316f3509577afd111710f9ebeefa15e12f72347d9dffd0d65ae3bade81604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a18073ffffffffffffffffffffffffffffffffffffffff167f7efef9ea3f60ddc038e50cccec621f86a0195894dc0520482abf8b5c6b659e4160405180905060405180910390a28181604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a05b5050565b6000600060008585859250925092505b935093509390505600a165627a7a72305820aaf842d0d0c35c45622c5263cbb54813d2974d3999c8c38551d7c613ea2bc1170029",
      "storage": {
        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x1234",
        "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9": "0x01"
      }
    },
    "0000000000000000000000000000000000000315": {
      "balance": "0x9999999999999999999999999999999",
      "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ef2769ca1461003e575b610000565b3461000057610078600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061007a565b005b8173ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051809050600060405180830381858888f1935050505015610106578173ffffffffffffffffffffffffffffffffffffffff167f30a3c50752f2552dcc2b93f5b96866280816a986c0c0408cb6778b9fa198288f826040518082815260200191505060405180910390a25b5b50505600a165627a7a72305820637991fabcc8abad4294bf2bb615db78fbec4edff1635a2647d3894e2daf6a610029"
    }
  }
}
```
to run fakenet with a genesis file

```sh
opera --fakenet=1/1 --init=genesis.json
```