### PR TITLE
fix of db_size metric calc

### DIFF
--- a/demo/start.sh
+++ b/demo/start.sh
@@ -25,6 +25,7 @@ do
 	--nat extip:127.0.0.1 \
 	--http --http.addr="127.0.0.1" --http.port=${RPCP} --http.corsdomain="*" --http.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
 	--ws --ws.addr="127.0.0.1" --ws.port=${WSP} --ws.origins="*" --ws.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag" \
+	--metrics --metrics.addr=127.0.0.1 --metrics.port=$(($RPCP+1100)) \
 	--verbosity=3 --tracing >> opera$i.log 2>&1)&
 
     echo -e "\tnode$i ok"


### PR DESCRIPTION
Moves db_size metric calculation into singleton infinite loop, not on demand.
It is necessary because mainnet data dir is enough large and walking over the file tree takes a time.
Fixes the issue when metrics endpoint is really slow to respond.