### PR TITLE
Disconnect invalid and inactive peers

### DIFF
--- a/gossip/export_test.go
+++ b/gossip/export_test.go
@@ -1,0 +1,11 @@
+package gossip
+
+import "time"
+
+func setProgressThreshold(threshold time.Duration) {
+	noProgressTime = threshold
+}
+
+func setApplicationThreshold(threshold time.Duration) {
+	noAppMessageTime = threshold
+}

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -817,7 +817,6 @@ func (h *handler) handle(p *peer) error {
 		return p2p.DiscTooManyPeers
 	}
 
-
 	h.peerWG.Add(1)
 	defer h.peerWG.Done()
 
@@ -1043,6 +1042,11 @@ func (h *handler) handleMsg(p *peer) error {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
 		p.SetProgress(progress)
+
+		// If peer has not progressed for NoProgressCount times, then disconnect the peer.
+		if p.IsPeerNotProgressing() {
+			return errResp(ErrPeerNotProgressing, "%v: %v", "epoch is not progressing consecutively for ", NoProgressCount)
+		}
 
 	case msg.Code == EvmTxsMsg:
 		// Transactions arrived, make sure we have a valid and fresh graph to handle them

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -62,9 +62,6 @@ const (
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
 
-	// watchdog timer for monitoring peer messages
-	watchdogTimer = 3 * time.Minute
-
 	// percentage of useless peer nodes to allow
 	uselessPeerPercentage = 20 // 20%
 

--- a/gossip/peer_test.go
+++ b/gossip/peer_test.go
@@ -2,38 +2,50 @@ package gossip
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestPeerProgress(t *testing.T) {
-	newPeer := getPeer()
-
+func TestPeerProgressWithEpoch(t *testing.T) {
 	// Increment epoch and see if the peer is progressing
+	newPeer := getPeer()
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
+	time.Sleep(1 * time.Second) //set the threshold to 1 second
 	ep2 := PeerProgress{Epoch: 2}
 	newPeer.SetProgress(ep2)
-	ep3 := PeerProgress{Epoch: 3}
-	newPeer.SetProgress(ep3)
-	ep4 := PeerProgress{Epoch: 4}
-	newPeer.SetProgress(ep4)
-	require.False(t, newPeer.IsPeerNotProgressing(), "Peer is not progressing")
+	require.True(t, newPeer.IsPeerProgressing(), "Peer is not progressing")
+}
 
-	// Don't progress consecutively for 3 messages and see if the peer is
-	// being progress disconnected
-	ep5 := PeerProgress{Epoch: 4}
-	newPeer.SetProgress(ep5)
-	ep6 := PeerProgress{Epoch: 4}
-	newPeer.SetProgress(ep6)
-	ep7 := PeerProgress{Epoch: 4}
-	newPeer.SetProgress(ep7)
-	require.True(t, newPeer.IsPeerNotProgressing(), "Peer is progressing")
+func TestPeerNotProgressWithEpoch(t *testing.T) {
+	// Don't Increment epoch and check if the peer is not progressing
+	newPeer := getPeer()
+	newPeer.setProgressThreshold(1 * time.Second)
+	ep1 := PeerProgress{Epoch: 1}
+	newPeer.SetProgress(ep1)
+	time.Sleep(1 * time.Second) //set the threshold to 1 second
+	ep2 := PeerProgress{Epoch: 1}
+	newPeer.SetProgress(ep2)
+	require.False(t, newPeer.IsPeerProgressing(), "Peer is progressing")
+}
+
+func TestPeerProgressWithApplicationMessage(t *testing.T) {
+	// Don't Increment epoch, but add a valid application message and check if the peer is progressing
+	newPeer := getPeer()
+	newPeer.setProgressThreshold(1 * time.Second)
+	ep1 := PeerProgress{Epoch: 1}
+	newPeer.SetProgress(ep1)
+	time.Sleep(1 * time.Second) //set the threshold to 1 second
+	ep2 := PeerProgress{Epoch: 1}
+	newPeer.SetProgress(ep2)
+	newPeer.setPeerAsProgressing() // simulate receiving of a valid application message
+	require.True(t, newPeer.IsPeerProgressing(), "Peer is not progressing")
 }
 
 func getPeer() *peer {
 	peer := &peer{
-		notProgressingCount: 0,
+		lastProgressTime: time.Now(),
 	}
 	return peer
 }

--- a/gossip/peer_test.go
+++ b/gossip/peer_test.go
@@ -1,0 +1,39 @@
+package gossip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerProgress(t *testing.T) {
+	newPeer := getPeer()
+
+	// Increment epoch and see if the peer is progressing
+	ep1 := PeerProgress{Epoch: 1}
+	newPeer.SetProgress(ep1)
+	ep2 := PeerProgress{Epoch: 2}
+	newPeer.SetProgress(ep2)
+	ep3 := PeerProgress{Epoch: 3}
+	newPeer.SetProgress(ep3)
+	ep4 := PeerProgress{Epoch: 4}
+	newPeer.SetProgress(ep4)
+	require.False(t, newPeer.IsPeerNotProgressing(), "Peer is not progressing")
+
+	// Don't progress consecutively for 3 messages and see if the peer is
+	// being progress disconnected
+	ep5 := PeerProgress{Epoch: 4}
+	newPeer.SetProgress(ep5)
+	ep6 := PeerProgress{Epoch: 4}
+	newPeer.SetProgress(ep6)
+	ep7 := PeerProgress{Epoch: 4}
+	newPeer.SetProgress(ep7)
+	require.True(t, newPeer.IsPeerNotProgressing(), "Peer is progressing")
+}
+
+func getPeer() *peer {
+	peer := &peer{
+		notProgressingCount: 0,
+	}
+	return peer
+}

--- a/gossip/peer_test.go
+++ b/gossip/peer_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestPeerProgressWithEpoch(t *testing.T) {
 	// Increment epoch and see if the peer is progressing
+	setProgressThreshold(1 * time.Second)
 	newPeer := getPeer()
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(1 * time.Second) //set the threshold to 1 second
+	time.Sleep(2 * time.Second) //set the threshold to 2 second
 	ep2 := PeerProgress{Epoch: 2}
 	newPeer.SetProgress(ep2)
 	require.True(t, newPeer.IsPeerProgressing(), "Peer is not progressing")
@@ -20,32 +21,47 @@ func TestPeerProgressWithEpoch(t *testing.T) {
 
 func TestPeerNotProgressWithEpoch(t *testing.T) {
 	// Don't Increment epoch and check if the peer is not progressing
+	setProgressThreshold(1 * time.Second)
 	newPeer := getPeer()
-	newPeer.setProgressThreshold(1 * time.Second)
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(1 * time.Second) //set the threshold to 1 second
+	time.Sleep(2 * time.Second) //set the threshold to 2 second so that the threshold is expired
 	ep2 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep2)
 	require.False(t, newPeer.IsPeerProgressing(), "Peer is progressing")
 }
 
-func TestPeerProgressWithApplicationMessage(t *testing.T) {
-	// Don't Increment epoch, but add a valid application message and check if the peer is progressing
+func TestPeerNotProgressTimeout(t *testing.T) {
+	// Don't Increment epoch and check if the peer is not progressing
+	setProgressThreshold(1 * time.Second)
 	newPeer := getPeer()
-	newPeer.setProgressThreshold(1 * time.Second)
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(1 * time.Second) //set the threshold to 1 second
-	ep2 := PeerProgress{Epoch: 1}
-	newPeer.SetProgress(ep2)
-	newPeer.setPeerAsProgressing() // simulate receiving of a valid application message
-	require.True(t, newPeer.IsPeerProgressing(), "Peer is not progressing")
+	time.Sleep(2 * time.Second) //set the threshold to 2 second so that the timer expires
+	require.False(t, newPeer.IsPeerProgressing(), "Peer is progressing")
+}
+
+func TestApplicationProgressMessage(t *testing.T) {
+	// send a valid application message and check if the peer is progressing
+	setApplicationThreshold(2 * time.Second)
+	newPeer := getPeer()
+	newPeer.SetApplicationProgress() // simulate receiving of a valid application message
+	time.Sleep(1 * time.Second)      //set the threshold to 1 second
+	require.True(t, newPeer.IsApplicationProgressing(), "Application is not progressing")
+}
+
+func TestApplicationNotProgressingMessage(t *testing.T) {
+	// send a valid application message and check if the peer is progressing
+	setApplicationThreshold(1 * time.Second)
+	newPeer := getPeer()
+	newPeer.SetApplicationProgress() // simulate receiving of a valid application message
+	time.Sleep(2 * time.Second)      //set the threshold to 2 second so that the threshold timer expires
+	require.False(t, newPeer.IsApplicationProgressing(), "Application is progressing")
 }
 
 func getPeer() *peer {
 	peer := &peer{
-		lastProgressTime: time.Now(),
+		progressTime: time.Now(),
 	}
 	return peer
 }

--- a/gossip/peer_test.go
+++ b/gossip/peer_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestPeerProgressWithEpoch(t *testing.T) {
 	// Increment epoch and see if the peer is progressing
-	setProgressThreshold(1 * time.Second)
+	setProgressThreshold(10 * time.Millisecond)
 	newPeer := getPeer()
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(2 * time.Second) //set the threshold to 2 second
+	time.Sleep(20 * time.Millisecond) //set the threshold to 2 second
 	ep2 := PeerProgress{Epoch: 2}
 	newPeer.SetProgress(ep2)
 	require.True(t, newPeer.IsPeerProgressing(), "Peer is not progressing")
@@ -21,11 +21,11 @@ func TestPeerProgressWithEpoch(t *testing.T) {
 
 func TestPeerNotProgressWithEpoch(t *testing.T) {
 	// Don't Increment epoch and check if the peer is not progressing
-	setProgressThreshold(1 * time.Second)
+	setProgressThreshold(10 * time.Millisecond)
 	newPeer := getPeer()
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(2 * time.Second) //set the threshold to 2 second so that the threshold is expired
+	time.Sleep(20 * time.Millisecond) //set the threshold to 2 second so that the threshold is expired
 	ep2 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep2)
 	require.False(t, newPeer.IsPeerProgressing(), "Peer is progressing")
@@ -33,29 +33,29 @@ func TestPeerNotProgressWithEpoch(t *testing.T) {
 
 func TestPeerNotProgressTimeout(t *testing.T) {
 	// Don't Increment epoch and check if the peer is not progressing
-	setProgressThreshold(1 * time.Second)
+	setProgressThreshold(10 * time.Millisecond)
 	newPeer := getPeer()
 	ep1 := PeerProgress{Epoch: 1}
 	newPeer.SetProgress(ep1)
-	time.Sleep(2 * time.Second) //set the threshold to 2 second so that the timer expires
+	time.Sleep(20 * time.Millisecond) //set the threshold to 2 second so that the timer expires
 	require.False(t, newPeer.IsPeerProgressing(), "Peer is progressing")
 }
 
 func TestApplicationProgressMessage(t *testing.T) {
 	// send a valid application message and check if the peer is progressing
-	setApplicationThreshold(2 * time.Second)
+	setApplicationThreshold(20 * time.Millisecond)
 	newPeer := getPeer()
-	newPeer.SetApplicationProgress() // simulate receiving of a valid application message
-	time.Sleep(1 * time.Second)      //set the threshold to 1 second
+	newPeer.SetApplicationProgress()  // simulate receiving of a valid application message
+	time.Sleep(10 * time.Millisecond) //set the threshold to 1 second
 	require.True(t, newPeer.IsApplicationProgressing(), "Application is not progressing")
 }
 
 func TestApplicationNotProgressingMessage(t *testing.T) {
 	// send a valid application message and check if the peer is progressing
-	setApplicationThreshold(1 * time.Second)
+	setApplicationThreshold(10 * time.Millisecond)
 	newPeer := getPeer()
-	newPeer.SetApplicationProgress() // simulate receiving of a valid application message
-	time.Sleep(2 * time.Second)      //set the threshold to 2 second so that the threshold timer expires
+	newPeer.SetApplicationProgress()  // simulate receiving of a valid application message
+	time.Sleep(20 * time.Millisecond) //set the threshold to 2 second so that the threshold timer expires
 	require.False(t, newPeer.IsApplicationProgressing(), "Application is progressing")
 }
 

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -79,6 +79,7 @@ const (
 	ErrNoStatusMsg
 	ErrExtraStatusMsg
 	ErrSuspendedPeer
+	ErrPeerNotProgressing
 	ErrEmptyMessage = 0xf00
 )
 
@@ -97,6 +98,7 @@ var errorToString = map[int]string{
 	ErrNoStatusMsg:             "No status message",
 	ErrExtraStatusMsg:          "Extra status message",
 	ErrSuspendedPeer:           "Suspended peer",
+	ErrPeerNotProgressing:      "Peer not progressing",
 	ErrEmptyMessage:            "Empty message",
 }
 


### PR DESCRIPTION
This PR adds checks to identify and ban peers that pass the P2P handshake and are accepted into the application protocol but has other application-level issues.

- Some clients have valid caps (opera/63, fsnap/1) but invalid client names such as Efireal, go-corex, Geth etc.
- Progress message is checked if the Epoch increases for a nominal duration.
- Application message should be received within a threshold.
- Recurring Application error now results in banning the peer.

These checks have shown that peers that are valid and working honestly get priority.

Depends on https://github.com/Fantom-foundation/go-ethereum/pull/44