### PR TITLE
Automatically compact DB

### DIFF
--- a/cmd/opera/launcher/db-transform.go
+++ b/cmd/opera/launcher/db-transform.go
@@ -264,9 +264,9 @@ func transformComponent(datadir string, dbTypes, tmpDbTypes map[multidb.TypeName
 					return err
 				}
 				toMove[dbLocatorOf(e.New)] = true
-				newDB = batched.Wrap(autocompact.Wrap(autocompact.Wrap(newDB, 1*opt.GiB), 16*opt.GiB))
-				defer newDB.Close()
 				newHumanName := path.Join("tmp", string(e.New.Type), e.New.Name)
+				newDB = batched.Wrap(autocompact.Wrap2M(newDB, opt.GiB, 16*opt.GiB, true, newHumanName))
+				defer newDB.Close()
 				log.Info("Copying DB table", "req", e.Req, "old_db", oldHumanName, "old_table", e.Old.Table,
 					"new_db", newHumanName, "new_table", e.New.Table)
 				oldTable := utils.NewTableOrSelf(oldDB, []byte(e.Old.Table))

--- a/cmd/opera/launcher/db-transform.go
+++ b/cmd/opera/launcher/db-transform.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/Fantom-foundation/go-opera/integration"
 	"github.com/Fantom-foundation/go-opera/utils"
-	"github.com/Fantom-foundation/go-opera/utils/dbutil/compactdb"
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/autocompact"
 )
 
 func dbTransform(ctx *cli.Context) error {
@@ -264,7 +264,7 @@ func transformComponent(datadir string, dbTypes, tmpDbTypes map[multidb.TypeName
 					return err
 				}
 				toMove[dbLocatorOf(e.New)] = true
-				newDB = batched.Wrap(newDB)
+				newDB = batched.Wrap(autocompact.Wrap(autocompact.Wrap(newDB, 1*opt.GiB), 16*opt.GiB))
 				defer newDB.Close()
 				newHumanName := path.Join("tmp", string(e.New.Type), e.New.Name)
 				log.Info("Copying DB table", "req", e.Req, "old_db", oldHumanName, "old_table", e.Old.Table,
@@ -291,11 +291,6 @@ func transformComponent(datadir string, dbTypes, tmpDbTypes map[multidb.TypeName
 					}
 					keys = keys[:0]
 					values = values[:0]
-				}
-				err = compactdb.Compact(newTable, newHumanName, 16*opt.GiB)
-				if err != nil {
-					log.Error("Database compaction failed", "err", err)
-					return err
 				}
 				return nil
 			}()

--- a/cmd/opera/launcher/export.go
+++ b/cmd/opera/launcher/export.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/Fantom-foundation/go-opera/gossip"
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/autocompact"
 )
 
 var (
@@ -135,7 +136,7 @@ func exportEvmKeys(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	keysDB := batched.Wrap(keysDB_)
+	keysDB := batched.Wrap(autocompact.Wrap2M(keysDB_, opt.GiB, 16*opt.GiB, true, "evm-keys"))
 	defer keysDB.Close()
 
 	it := gdb.EvmStore().EvmDb.NewIterator(nil, nil)

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -78,10 +78,10 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (genesisHash hash.Hash, err erro
 func (s *Store) WrapTablesAsBatched() (unwrap func()) {
 	origTables := s.table
 
-	batchedBlocks := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.Blocks, 1*opt.GiB), 16*opt.GiB))
+	batchedBlocks := batched.Wrap(autocompact.Wrap2M(s.table.Blocks, opt.GiB, 16*opt.GiB, false, "blocks"))
 	s.table.Blocks = batchedBlocks
 
-	batchedBlockHashes := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.BlockHashes, 1*opt.GiB), 16*opt.GiB))
+	batchedBlockHashes := batched.Wrap(s.table.BlockHashes)
 	s.table.BlockHashes = batchedBlockHashes
 
 	unwrapEVM := s.evm.WrapTablesAsBatched()

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/batched"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/go-opera/inter/iblockproc"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
 	"github.com/Fantom-foundation/go-opera/inter/ier"
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/autocompact"
 )
 
 // ApplyGenesis writes initial state.
@@ -76,10 +78,10 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (genesisHash hash.Hash, err erro
 func (s *Store) WrapTablesAsBatched() (unwrap func()) {
 	origTables := s.table
 
-	batchedBlocks := batched.Wrap(s.table.Blocks)
+	batchedBlocks := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.Blocks, 1*opt.GiB), 16*opt.GiB))
 	s.table.Blocks = batchedBlocks
 
-	batchedBlockHashes := batched.Wrap(s.table.BlockHashes)
+	batchedBlockHashes := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.BlockHashes, 1*opt.GiB), 16*opt.GiB))
 	s.table.BlockHashes = batchedBlockHashes
 
 	unwrapEVM := s.evm.WrapTablesAsBatched()

--- a/gossip/evmstore/apply_genesis.go
+++ b/gossip/evmstore/apply_genesis.go
@@ -11,7 +11,7 @@ import (
 
 // ApplyGenesis writes initial state.
 func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
-	db := batched.Wrap(autocompact.Wrap(autocompact.Wrap(ethdb2kvdb.Wrap(s.EvmDb), 1*opt.GiB), 16*opt.GiB))
+	db := batched.Wrap(autocompact.Wrap2M(ethdb2kvdb.Wrap(s.EvmDb), opt.GiB, 16*opt.GiB, true, "evm"))
 	g.RawEvmItems.ForEach(func(key, value []byte) bool {
 		err = db.Put(key, value)
 		if err != nil {
@@ -36,7 +36,7 @@ func (s *Store) WrapTablesAsBatched() (unwrap func()) {
 
 	unwrapLogs := s.EvmLogs.WrapTablesAsBatched()
 
-	batchedReceipts := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.Receipts, opt.GiB), 16*opt.GiB))
+	batchedReceipts := batched.Wrap(autocompact.Wrap2M(s.table.Receipts, opt.GiB, 16*opt.GiB, false, "receipts"))
 	s.table.Receipts = batchedReceipts
 	return func() {
 		_ = batchedTxs.Flush()

--- a/gossip/evmstore/apply_genesis.go
+++ b/gossip/evmstore/apply_genesis.go
@@ -1,37 +1,28 @@
 package evmstore
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/batched"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/Fantom-foundation/go-opera/opera/genesis"
+	"github.com/Fantom-foundation/go-opera/utils/adapters/ethdb2kvdb"
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/autocompact"
 )
 
 // ApplyGenesis writes initial state.
 func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
-	batch := s.EvmDb.NewBatch()
-	defer batch.Reset()
+	db := batched.Wrap(autocompact.Wrap(autocompact.Wrap(ethdb2kvdb.Wrap(s.EvmDb), 1*opt.GiB), 16*opt.GiB))
 	g.RawEvmItems.ForEach(func(key, value []byte) bool {
+		err = db.Put(key, value)
 		if err != nil {
 			return false
-		}
-		err = batch.Put(key, value)
-		if err != nil {
-			return false
-		}
-		if batch.ValueSize() > kvdb.IdealBatchSize {
-			err = batch.Write()
-			if err != nil {
-				return false
-			}
-			batch.Reset()
 		}
 		return true
 	})
 	if err != nil {
 		return err
 	}
-	return batch.Write()
+	return db.Write()
 }
 
 func (s *Store) WrapTablesAsBatched() (unwrap func()) {
@@ -45,7 +36,7 @@ func (s *Store) WrapTablesAsBatched() (unwrap func()) {
 
 	unwrapLogs := s.EvmLogs.WrapTablesAsBatched()
 
-	batchedReceipts := batched.Wrap(s.table.Receipts)
+	batchedReceipts := batched.Wrap(autocompact.Wrap(autocompact.Wrap(s.table.Receipts, opt.GiB), 16*opt.GiB))
 	s.table.Receipts = batchedReceipts
 	return func() {
 		_ = batchedTxs.Flush()

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
+	"github.com/Fantom-foundation/go-opera/utils/dbutil/autocompact"
 	"github.com/Fantom-foundation/go-opera/utils/dbutil/compactdb"
 )
 
@@ -46,7 +47,7 @@ type transformTask struct {
 
 func transform(m transformTask) error {
 	openDst := func() *batched.Store {
-		return batched.Wrap(m.openDst())
+		return batched.Wrap(autocompact.Wrap(autocompact.Wrap(m.openDst(), 1*opt.GiB), 16*opt.GiB))
 	}
 	openSrc := func() *batched.Store {
 		return batched.Wrap(m.openSrc())

--- a/integration/legacy_migrate.go
+++ b/integration/legacy_migrate.go
@@ -47,7 +47,7 @@ type transformTask struct {
 
 func transform(m transformTask) error {
 	openDst := func() *batched.Store {
-		return batched.Wrap(autocompact.Wrap(autocompact.Wrap(m.openDst(), 1*opt.GiB), 16*opt.GiB))
+		return batched.Wrap(autocompact.Wrap2M(m.openDst(), opt.GiB, 16*opt.GiB, true, ""))
 	}
 	openSrc := func() *batched.Store {
 		return batched.Wrap(m.openSrc())

--- a/utils/dbutil/autocompact/store.go
+++ b/utils/dbutil/autocompact/store.go
@@ -1,0 +1,124 @@
+package autocompact
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type Store struct {
+	kvdb.Store
+	minKey  []byte
+	maxKey  []byte
+	written uint64
+	limit   uint64
+	compMu  sync.Mutex
+}
+
+type Batch struct {
+	kvdb.Batch
+	written uint64
+	minKey  []byte
+	maxKey  []byte
+	onWrite func(key []byte, size uint64, force bool)
+}
+
+func Wrap(s kvdb.Store, limit uint64) *Store {
+	return &Store{
+		Store: s,
+		limit: limit,
+	}
+}
+
+func (s *Store) onWrite(key []byte, size uint64, force bool) {
+	s.compMu.Lock()
+	defer s.compMu.Unlock()
+	s.written += size
+	if s.minKey == nil {
+		s.minKey = common.CopyBytes(key)
+		s.maxKey = common.CopyBytes(key)
+	}
+	if key != nil && bytes.Compare(key, s.minKey) < 0 {
+		s.minKey = common.CopyBytes(key)
+	}
+	if key != nil && bytes.Compare(key, s.maxKey) > 0 {
+		s.maxKey = common.CopyBytes(key)
+	}
+	if force || s.written > s.limit {
+		_ = s.Store.Compact(s.minKey, s.maxKey)
+		s.written = 0
+		s.minKey = nil
+		s.maxKey = nil
+	}
+}
+
+func (s *Store) Put(key []byte, value []byte) error {
+	defer s.onWrite(key, uint64(len(key)+len(value)+64), false)
+	return s.Store.Put(key, value)
+}
+
+func (s *Store) Delete(key []byte) error {
+	defer s.onWrite(key, uint64(len(key)+64), false)
+	return s.Store.Delete(key)
+}
+
+func (s *Store) Close() error {
+	s.onWrite(nil, 0, true)
+	return s.Store.Close()
+}
+
+func (s *Store) NewBatch() kvdb.Batch {
+	batch := s.Store.NewBatch()
+	if batch == nil {
+		return nil
+	}
+	return &Batch{
+		Batch:   batch,
+		onWrite: s.onWrite,
+	}
+}
+
+func (s *Batch) Put(key []byte, value []byte) error {
+	s.written += uint64(len(key) + len(value) + 64)
+	if s.minKey == nil {
+		s.minKey = common.CopyBytes(key)
+		s.maxKey = common.CopyBytes(key)
+	}
+	if bytes.Compare(key, s.minKey) < 0 {
+		s.minKey = common.CopyBytes(key)
+	}
+	if bytes.Compare(key, s.maxKey) > 0 {
+		s.maxKey = common.CopyBytes(key)
+	}
+	return s.Batch.Put(key, value)
+}
+
+func (s *Batch) Delete(key []byte) error {
+	s.written += uint64(len(key) + 64)
+	if s.minKey == nil {
+		s.minKey = common.CopyBytes(key)
+		s.maxKey = common.CopyBytes(key)
+	}
+	if bytes.Compare(key, s.minKey) < 0 {
+		s.minKey = common.CopyBytes(key)
+	}
+	if bytes.Compare(key, s.maxKey) > 0 {
+		s.maxKey = common.CopyBytes(key)
+	}
+	return s.Batch.Delete(key)
+}
+
+func (s *Batch) Reset() {
+	s.written = 0
+	s.minKey = nil
+	s.maxKey = nil
+	s.Batch.Reset()
+}
+
+func (s *Batch) Write() error {
+	s.onWrite(s.minKey, 0, false)
+	defer s.onWrite(s.maxKey, s.written, false)
+	return s.Batch.Write()
+}

--- a/utils/dbutil/autocompact/strategy.go
+++ b/utils/dbutil/autocompact/strategy.go
@@ -1,0 +1,137 @@
+package autocompact
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type ContainerI interface {
+	Add(key []byte, size uint64)
+	Merge(c ContainerI)
+	Error() error
+	Reset()
+	Size() uint64
+	Ranges() []Range
+}
+
+type Range struct {
+	minKey []byte
+	maxKey []byte
+}
+
+// MonotonicContainer implements tracking of compaction ranges in cases when keys are inserted as series of monotonic ranges
+type MonotonicContainer struct {
+	forward bool
+	ranges  []Range
+	size    uint64
+	err     error
+}
+
+type DevnullContainer struct{}
+
+func (d DevnullContainer) Add(key []byte, size uint64) {}
+
+func (d DevnullContainer) Merge(c ContainerI) {}
+
+func (d DevnullContainer) Error() error {
+	return nil
+}
+
+func (d DevnullContainer) Reset() {
+
+}
+
+func (d DevnullContainer) Size() uint64 {
+	return 0
+}
+
+func (d DevnullContainer) Ranges() []Range {
+	return []Range{}
+}
+
+func NewForwardCont() ContainerI {
+	return &MonotonicContainer{
+		forward: true,
+	}
+}
+
+func NewBackwardsCont() ContainerI {
+	return &MonotonicContainer{
+		forward: false,
+	}
+}
+
+func NewDevnullCont() ContainerI {
+	return DevnullContainer{}
+}
+
+func (m *MonotonicContainer) addRange(key []byte) {
+	m.ranges = append(m.ranges, Range{
+		minKey: common.CopyBytes(key),
+		maxKey: common.CopyBytes(key),
+	})
+}
+
+func (m *MonotonicContainer) Add(key []byte, size uint64) {
+	m.size += size
+	if len(m.ranges) == 0 {
+		m.addRange(key)
+	}
+	// extend the last range if it's a monotonic addition or start new range otherwise
+	l := len(m.ranges) - 1
+	if m.forward {
+		if bytes.Compare(key, m.ranges[l].maxKey) >= 0 {
+			m.ranges[l].maxKey = common.CopyBytes(key)
+		} else {
+			m.addRange(key)
+		}
+	} else {
+		if bytes.Compare(key, m.ranges[l].minKey) <= 0 {
+			m.ranges[l].minKey = common.CopyBytes(key)
+		} else {
+			m.addRange(key)
+		}
+	}
+}
+
+func (m *MonotonicContainer) Merge(c ContainerI) {
+	if err := c.Error(); err != nil {
+		m.err = err
+	}
+
+	for _, r := range c.Ranges() {
+		if m.forward {
+			m.Add(r.minKey, 0)
+			m.Add(r.maxKey, 0)
+		} else {
+			m.Add(r.maxKey, 0)
+			m.Add(r.minKey, 0)
+		}
+	}
+	m.size += c.Size()
+}
+
+func (m *MonotonicContainer) Error() error {
+	if m.err != nil {
+		return m.err
+	}
+	if len(m.ranges) > 2 {
+		return errors.New("too many compaction ranges, it's likely that dataset isn't monotonic enough")
+	}
+	return nil
+}
+
+func (m *MonotonicContainer) Reset() {
+	m.ranges = nil
+	m.size = 0
+}
+
+func (m *MonotonicContainer) Size() uint64 {
+	return m.size
+}
+
+func (m *MonotonicContainer) Ranges() []Range {
+	return m.ranges
+}


### PR DESCRIPTION
- automatically compact DB during genesis processing, legacy migration and DB transformation in order to avoid compaction-related performance issues during data insertion

Fix #433