### PR TITLE
Added dynamic and static ban

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -893,7 +893,7 @@ func (h *handler) handle(p *peer) error {
 				progressWatchDogTimer.Reset(noProgressTime)
 			} else {
 				p.Log().Warn("progress timer timeout: ", "name", p.Name(), "node", p.Node().String())
-				discfilter.Dynamic(p.ID(), dynamicBanTime)
+				discfilter.BanDynamic(p.ID(), dynamicBanTime)
 				return ErrorProgressTimeout
 			}
 		case <-applicationWatchDogTimer.C:
@@ -901,7 +901,7 @@ func (h *handler) handle(p *peer) error {
 				applicationWatchDogTimer.Reset(noAppMessageTime)
 			} else {
 				p.Log().Warn("application timer timeout: ", "name", p.Name(), "node", p.Node().String())
-				discfilter.Dynamic(p.ID(), dynamicBanTime)
+				discfilter.BanDynamic(p.ID(), dynamicBanTime)
 				return ErrorApplicationTimeout
 			}
 		default:
@@ -909,14 +909,14 @@ func (h *handler) handle(p *peer) error {
 			if err != nil {
 				p.Log().Debug("Message handling failed", "err", err)
 				if strings.Contains(err.Error(), errorToString[ErrPeerNotProgressing]) {
-					discfilter.Dynamic(p.ID(), dynamicBanTime)
+					discfilter.BanDynamic(p.ID(), dynamicBanTime)
 					return err
 				}
 				// Ban peer and disconnect if the number of errors in the handling of application message
 				// crosses a threshold.
 				noOfApplicationErrors++
 				if noOfApplicationErrors > toleranceOfApplicationErrors {
-					discfilter.Dynamic(p.ID(), dynamicBanTime)
+					discfilter.BanDynamic(p.ID(), dynamicBanTime)
 					return err
 				}
 			}

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -67,10 +67,13 @@ const (
 
 	// Number of application errors that can be tolerated before banning the node and disconnecting
 	toleranceOfApplicationErrors = 3
+
+	// time for soft ban
+	dynamicBanTime = 4 * time.Hour
 )
 
 var (
-	ErrorProgressTimeout = errors.New("progress timeout")
+	ErrorProgressTimeout    = errors.New("progress timeout")
 	ErrorApplicationTimeout = errors.New("application timeout")
 )
 
@@ -798,7 +801,7 @@ func (h *handler) handle(p *peer) error {
 	// protocol handler. We should band these clients immediately.
 	// ex: go-corex, Efireal, Geth all with caps=[opera/62]
 	if !strings.Contains(strings.ToLower(p.Name()), "opera") {
-		discfilter.Ban(p.ID())
+		discfilter.BanStatic(p.ID())
 		return p2p.DiscProtocolError
 	}
 
@@ -827,7 +830,7 @@ func (h *handler) handle(p *peer) error {
 	)
 	if err := p.Handshake(h.NetworkID, myProgress, common.Hash(genesis)); err != nil {
 		p.Log().Debug("Handshake failed", "err", err)
-		discfilter.Ban(p.ID())
+		discfilter.BanStatic(p.ID())
 		return err
 	}
 
@@ -890,15 +893,15 @@ func (h *handler) handle(p *peer) error {
 				progressWatchDogTimer.Reset(noProgressTime)
 			} else {
 				p.Log().Warn("progress timer timeout: ", "name", p.Name(), "node", p.Node().String())
-				discfilter.Ban(p.ID())
+				discfilter.Dynamic(p.ID(), dynamicBanTime)
 				return ErrorProgressTimeout
 			}
-		case <- applicationWatchDogTimer.C:
+		case <-applicationWatchDogTimer.C:
 			if p.IsApplicationProgressing() {
 				applicationWatchDogTimer.Reset(noAppMessageTime)
 			} else {
 				p.Log().Warn("application timer timeout: ", "name", p.Name(), "node", p.Node().String())
-				discfilter.Ban(p.ID())
+				discfilter.Dynamic(p.ID(), dynamicBanTime)
 				return ErrorApplicationTimeout
 			}
 		default:
@@ -906,14 +909,14 @@ func (h *handler) handle(p *peer) error {
 			if err != nil {
 				p.Log().Debug("Message handling failed", "err", err)
 				if strings.Contains(err.Error(), errorToString[ErrPeerNotProgressing]) {
-					discfilter.Ban(p.ID())
+					discfilter.Dynamic(p.ID(), dynamicBanTime)
 					return err
 				}
 				// Ban peer and disconnect if the number of errors in the handling of application message
 				// crosses a threshold.
 				noOfApplicationErrors++
 				if noOfApplicationErrors > toleranceOfApplicationErrors {
-					discfilter.Ban(p.ID())
+					discfilter.Dynamic(p.ID(), dynamicBanTime)
 					return err
 				}
 			}


### PR DESCRIPTION
This PR uses the static and dynamic ban methods.
All serious errors will get a static ban and any application protocol error will attract a dynamic ban.

This PR is dependent on https://github.com/Fantom-foundation/go-ethereum/pull/45
Also this PR should be merged after merging https://github.com/Fantom-foundation/go-opera/pull/431