### PR TITLE
Update redundant ports in Dockerfile

### DIFF
--- a/docker/Dockerfile.opera
+++ b/docker/Dockerfile.opera
@@ -17,6 +17,6 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/go-opera/build/opera /
 
-EXPOSE 5050 18545 18546 18547 19090
+EXPOSE 5050 18545 18546 
 
 ENTRYPOINT ["/opera"]


### PR DESCRIPTION
It looks like the file `docker/Dockefile.opera`  is obsolete. This PR proposes to remove it.