### PR TITLE
Optimize tracking of transaction timestamps

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
+	"github.com/Fantom-foundation/go-opera/utils/txtime"
 )
 
 const (
@@ -898,6 +899,7 @@ func (pool *TxPool) AddRemote(tx *types.Transaction) error {
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
+	arrivedAt := time.Now()
 	// Filter out known ones without obtaining the pool lock or recovering signatures
 	var (
 		errs = make([]error, len(txs))
@@ -929,6 +931,13 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 	pool.mu.Lock()
 	newErrs, dirtyAddrs := pool.addTxsLocked(news, local)
 	pool.mu.Unlock()
+
+	// memorize tx time of validated transactions
+	for i, tx := range news {
+		if newErrs[i] == nil {
+			txtime.Validated(tx.Hash(), arrivedAt)
+		}
+	}
 
 	var nilSlot = 0
 	for _, err := range newErrs {

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -14,9 +14,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/utils/piecefunc"
 	"github.com/ethereum/go-ethereum/core/types"
-	lru "github.com/hashicorp/golang-lru"
 
-	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter/originatedtxs"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/logger"
@@ -30,8 +28,6 @@ const (
 )
 
 type Emitter struct {
-	txTime *lru.Cache // tx hash -> tx time
-
 	config Config
 
 	world World
@@ -98,12 +94,10 @@ func NewEmitter(
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	config.EmitIntervals = config.EmitIntervals.RandomizeEmitTime(r)
 
-	txTime, _ := lru.New(TxTimeBufferSize)
 	return &Emitter{
 		config:            config,
 		world:             world,
 		originatedTxs:     originatedtxs.New(SenderCountBufferSize),
-		txTime:            txTime,
 		intervals:         config.EmitIntervals,
 		Periodic:          logger.Periodic{Instance: logger.New()},
 		validatorVersions: make(map[idx.ValidatorID]uint64),
@@ -142,9 +136,6 @@ func (em *Emitter) Start() {
 	em.init()
 	em.done = make(chan struct{})
 
-	newTxsCh := make(chan evmcore.NewTxsNotify)
-	em.world.TxPool.SubscribeNewTxsNotify(newTxsCh)
-
 	done := em.done
 	if em.config.EmitIntervals.Min == 0 {
 		return
@@ -157,8 +148,6 @@ func (em *Emitter) Start() {
 		defer timer.Stop()
 		for {
 			select {
-			case txNotify := <-newTxsCh:
-				em.memorizeTxTimes(txNotify.Txs)
 			case <-timer.C:
 				em.tick()
 				timer.Reset(tick)

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/integration/makefakegenesis"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/opera"
+	"github.com/Fantom-foundation/go-opera/utils/txtime"
 	"github.com/Fantom-foundation/go-opera/vecmt"
 )
 
@@ -80,25 +81,32 @@ func TestEmitter(t *testing.T) {
 	})
 
 	t.Run("memorizeTxTimes", func(t *testing.T) {
+		txtime.Enabled = true
 		require := require.New(t)
-		tx := types.NewTransaction(1, common.Address{}, big.NewInt(1), 1, big.NewInt(1), nil)
+		tx1 := types.NewTransaction(1, common.Address{}, big.NewInt(1), 1, big.NewInt(1), nil)
+		tx2 := types.NewTransaction(2, common.Address{}, big.NewInt(2), 2, big.NewInt(2), nil)
 
 		external.EXPECT().IsBusy().
 			Return(true).
 			AnyTimes()
 
-		_, ok := em.txTime.Get(tx.Hash())
-		require.False(ok)
+		txtime.Saw(tx1.Hash(), time.Unix(1, 0))
 
-		before := time.Now()
-		em.memorizeTxTimes(types.Transactions{tx})
-		after := time.Now()
+		require.Equal(time.Unix(1, 0), txtime.Of(tx1.Hash()))
+		txtime.Saw(tx1.Hash(), time.Unix(2, 0))
+		require.Equal(time.Unix(1, 0), txtime.Of(tx1.Hash()))
+		txtime.Validated(tx1.Hash(), time.Unix(2, 0))
+		require.Equal(time.Unix(1, 0), txtime.Of(tx1.Hash()))
 
-		cached, ok := em.txTime.Get(tx.Hash())
-		got := cached.(time.Time)
-		require.True(ok)
-		require.True(got.After(before))
-		require.True(got.Before(after))
+		// reversed order
+		txtime.Validated(tx2.Hash(), time.Unix(3, 0))
+		txtime.Saw(tx2.Hash(), time.Unix(2, 0))
+
+		require.Equal(time.Unix(3, 0), txtime.Of(tx2.Hash()))
+		txtime.Saw(tx2.Hash(), time.Unix(3, 0))
+		require.Equal(time.Unix(3, 0), txtime.Of(tx2.Hash()))
+		txtime.Validated(tx2.Hash(), time.Unix(3, 0))
+		require.Equal(time.Unix(3, 0), txtime.Of(tx2.Hash()))
 	})
 
 	t.Run("tick", func(t *testing.T) {

--- a/gossip/emitter/mock/world.go
+++ b/gossip/emitter/mock/world.go
@@ -5,7 +5,9 @@
 package mock
 
 import (
-	evmcore "github.com/Fantom-foundation/go-opera/evmcore"
+	big "math/big"
+	reflect "reflect"
+
 	inter "github.com/Fantom-foundation/go-opera/inter"
 	validatorpk "github.com/Fantom-foundation/go-opera/inter/validatorpk"
 	opera "github.com/Fantom-foundation/go-opera/opera"
@@ -15,48 +17,45 @@ import (
 	pos "github.com/Fantom-foundation/lachesis-base/inter/pos"
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
-	event "github.com/ethereum/go-ethereum/event"
 	gomock "github.com/golang/mock/gomock"
-	big "math/big"
-	reflect "reflect"
 )
 
-// MockExternal is a mock of External interface
+// MockExternal is a mock of External interface.
 type MockExternal struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalMockRecorder
 }
 
-// MockExternalMockRecorder is the mock recorder for MockExternal
+// MockExternalMockRecorder is the mock recorder for MockExternal.
 type MockExternalMockRecorder struct {
 	mock *MockExternal
 }
 
-// NewMockExternal creates a new mock instance
+// NewMockExternal creates a new mock instance.
 func NewMockExternal(ctrl *gomock.Controller) *MockExternal {
 	mock := &MockExternal{ctrl: ctrl}
 	mock.recorder = &MockExternalMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternal) EXPECT() *MockExternalMockRecorder {
 	return m.recorder
 }
 
-// Broadcast mocks base method
+// Broadcast mocks base method.
 func (m *MockExternal) Broadcast(arg0 *inter.EventPayload) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Broadcast", arg0)
 }
 
-// Broadcast indicates an expected call of Broadcast
+// Broadcast indicates an expected call of Broadcast.
 func (mr *MockExternalMockRecorder) Broadcast(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockExternal)(nil).Broadcast), arg0)
 }
 
-// Build mocks base method
+// Build mocks base method.
 func (m *MockExternal) Build(arg0 *inter.MutableEventPayload, arg1 func()) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Build", arg0, arg1)
@@ -64,13 +63,13 @@ func (m *MockExternal) Build(arg0 *inter.MutableEventPayload, arg1 func()) error
 	return ret0
 }
 
-// Build indicates an expected call of Build
+// Build indicates an expected call of Build.
 func (mr *MockExternalMockRecorder) Build(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockExternal)(nil).Build), arg0, arg1)
 }
 
-// Check mocks base method
+// Check mocks base method.
 func (m *MockExternal) Check(arg0 *inter.EventPayload, arg1 inter.Events) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Check", arg0, arg1)
@@ -78,13 +77,13 @@ func (m *MockExternal) Check(arg0 *inter.EventPayload, arg1 inter.Events) error 
 	return ret0
 }
 
-// Check indicates an expected call of Check
+// Check indicates an expected call of Check.
 func (mr *MockExternalMockRecorder) Check(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockExternal)(nil).Check), arg0, arg1)
 }
 
-// DagIndex mocks base method
+// DagIndex mocks base method.
 func (m *MockExternal) DagIndex() *vecmt.Index {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DagIndex")
@@ -92,13 +91,13 @@ func (m *MockExternal) DagIndex() *vecmt.Index {
 	return ret0
 }
 
-// DagIndex indicates an expected call of DagIndex
+// DagIndex indicates an expected call of DagIndex.
 func (mr *MockExternalMockRecorder) DagIndex() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DagIndex", reflect.TypeOf((*MockExternal)(nil).DagIndex))
 }
 
-// GetBlockEpoch mocks base method
+// GetBlockEpoch mocks base method.
 func (m *MockExternal) GetBlockEpoch(arg0 idx.Block) idx.Epoch {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockEpoch", arg0)
@@ -106,13 +105,13 @@ func (m *MockExternal) GetBlockEpoch(arg0 idx.Block) idx.Epoch {
 	return ret0
 }
 
-// GetBlockEpoch indicates an expected call of GetBlockEpoch
+// GetBlockEpoch indicates an expected call of GetBlockEpoch.
 func (mr *MockExternalMockRecorder) GetBlockEpoch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockEpoch", reflect.TypeOf((*MockExternal)(nil).GetBlockEpoch), arg0)
 }
 
-// GetBlockRecordHash mocks base method
+// GetBlockRecordHash mocks base method.
 func (m *MockExternal) GetBlockRecordHash(arg0 idx.Block) *hash.Hash {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockRecordHash", arg0)
@@ -120,13 +119,13 @@ func (m *MockExternal) GetBlockRecordHash(arg0 idx.Block) *hash.Hash {
 	return ret0
 }
 
-// GetBlockRecordHash indicates an expected call of GetBlockRecordHash
+// GetBlockRecordHash indicates an expected call of GetBlockRecordHash.
 func (mr *MockExternalMockRecorder) GetBlockRecordHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockRecordHash", reflect.TypeOf((*MockExternal)(nil).GetBlockRecordHash), arg0)
 }
 
-// GetEpochRecordHash mocks base method
+// GetEpochRecordHash mocks base method.
 func (m *MockExternal) GetEpochRecordHash(arg0 idx.Epoch) *hash.Hash {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEpochRecordHash", arg0)
@@ -134,13 +133,13 @@ func (m *MockExternal) GetEpochRecordHash(arg0 idx.Epoch) *hash.Hash {
 	return ret0
 }
 
-// GetEpochRecordHash indicates an expected call of GetEpochRecordHash
+// GetEpochRecordHash indicates an expected call of GetEpochRecordHash.
 func (mr *MockExternalMockRecorder) GetEpochRecordHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochRecordHash", reflect.TypeOf((*MockExternal)(nil).GetEpochRecordHash), arg0)
 }
 
-// GetEpochValidators mocks base method
+// GetEpochValidators mocks base method.
 func (m *MockExternal) GetEpochValidators() (*pos.Validators, idx.Epoch) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEpochValidators")
@@ -149,13 +148,13 @@ func (m *MockExternal) GetEpochValidators() (*pos.Validators, idx.Epoch) {
 	return ret0, ret1
 }
 
-// GetEpochValidators indicates an expected call of GetEpochValidators
+// GetEpochValidators indicates an expected call of GetEpochValidators.
 func (mr *MockExternalMockRecorder) GetEpochValidators() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochValidators", reflect.TypeOf((*MockExternal)(nil).GetEpochValidators))
 }
 
-// GetEvent mocks base method
+// GetEvent mocks base method.
 func (m *MockExternal) GetEvent(arg0 hash.Event) *inter.Event {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEvent", arg0)
@@ -163,13 +162,13 @@ func (m *MockExternal) GetEvent(arg0 hash.Event) *inter.Event {
 	return ret0
 }
 
-// GetEvent indicates an expected call of GetEvent
+// GetEvent indicates an expected call of GetEvent.
 func (mr *MockExternalMockRecorder) GetEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockExternal)(nil).GetEvent), arg0)
 }
 
-// GetEventPayload mocks base method
+// GetEventPayload mocks base method.
 func (m *MockExternal) GetEventPayload(arg0 hash.Event) *inter.EventPayload {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEventPayload", arg0)
@@ -177,13 +176,13 @@ func (m *MockExternal) GetEventPayload(arg0 hash.Event) *inter.EventPayload {
 	return ret0
 }
 
-// GetEventPayload indicates an expected call of GetEventPayload
+// GetEventPayload indicates an expected call of GetEventPayload.
 func (mr *MockExternalMockRecorder) GetEventPayload(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventPayload", reflect.TypeOf((*MockExternal)(nil).GetEventPayload), arg0)
 }
 
-// GetGenesisTime mocks base method
+// GetGenesisTime mocks base method.
 func (m *MockExternal) GetGenesisTime() inter.Timestamp {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGenesisTime")
@@ -191,13 +190,13 @@ func (m *MockExternal) GetGenesisTime() inter.Timestamp {
 	return ret0
 }
 
-// GetGenesisTime indicates an expected call of GetGenesisTime
+// GetGenesisTime indicates an expected call of GetGenesisTime.
 func (mr *MockExternalMockRecorder) GetGenesisTime() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesisTime", reflect.TypeOf((*MockExternal)(nil).GetGenesisTime))
 }
 
-// GetHeads mocks base method
+// GetHeads mocks base method.
 func (m *MockExternal) GetHeads(arg0 idx.Epoch) hash.Events {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeads", arg0)
@@ -205,13 +204,13 @@ func (m *MockExternal) GetHeads(arg0 idx.Epoch) hash.Events {
 	return ret0
 }
 
-// GetHeads indicates an expected call of GetHeads
+// GetHeads indicates an expected call of GetHeads.
 func (mr *MockExternalMockRecorder) GetHeads(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeads", reflect.TypeOf((*MockExternal)(nil).GetHeads), arg0)
 }
 
-// GetLastBV mocks base method
+// GetLastBV mocks base method.
 func (m *MockExternal) GetLastBV(arg0 idx.ValidatorID) *idx.Block {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLastBV", arg0)
@@ -219,13 +218,13 @@ func (m *MockExternal) GetLastBV(arg0 idx.ValidatorID) *idx.Block {
 	return ret0
 }
 
-// GetLastBV indicates an expected call of GetLastBV
+// GetLastBV indicates an expected call of GetLastBV.
 func (mr *MockExternalMockRecorder) GetLastBV(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastBV", reflect.TypeOf((*MockExternal)(nil).GetLastBV), arg0)
 }
 
-// GetLastEV mocks base method
+// GetLastEV mocks base method.
 func (m *MockExternal) GetLastEV(arg0 idx.ValidatorID) *idx.Epoch {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLastEV", arg0)
@@ -233,13 +232,13 @@ func (m *MockExternal) GetLastEV(arg0 idx.ValidatorID) *idx.Epoch {
 	return ret0
 }
 
-// GetLastEV indicates an expected call of GetLastEV
+// GetLastEV indicates an expected call of GetLastEV.
 func (mr *MockExternalMockRecorder) GetLastEV(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastEV", reflect.TypeOf((*MockExternal)(nil).GetLastEV), arg0)
 }
 
-// GetLastEvent mocks base method
+// GetLastEvent mocks base method.
 func (m *MockExternal) GetLastEvent(arg0 idx.Epoch, arg1 idx.ValidatorID) *hash.Event {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLastEvent", arg0, arg1)
@@ -247,13 +246,13 @@ func (m *MockExternal) GetLastEvent(arg0 idx.Epoch, arg1 idx.ValidatorID) *hash.
 	return ret0
 }
 
-// GetLastEvent indicates an expected call of GetLastEvent
+// GetLastEvent indicates an expected call of GetLastEvent.
 func (mr *MockExternalMockRecorder) GetLastEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastEvent", reflect.TypeOf((*MockExternal)(nil).GetLastEvent), arg0, arg1)
 }
 
-// GetLatestBlockIndex mocks base method
+// GetLatestBlockIndex mocks base method.
 func (m *MockExternal) GetLatestBlockIndex() idx.Block {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestBlockIndex")
@@ -261,13 +260,13 @@ func (m *MockExternal) GetLatestBlockIndex() idx.Block {
 	return ret0
 }
 
-// GetLatestBlockIndex indicates an expected call of GetLatestBlockIndex
+// GetLatestBlockIndex indicates an expected call of GetLatestBlockIndex.
 func (mr *MockExternalMockRecorder) GetLatestBlockIndex() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestBlockIndex", reflect.TypeOf((*MockExternal)(nil).GetLatestBlockIndex))
 }
 
-// GetLowestBlockToDecide mocks base method
+// GetLowestBlockToDecide mocks base method.
 func (m *MockExternal) GetLowestBlockToDecide() idx.Block {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLowestBlockToDecide")
@@ -275,13 +274,13 @@ func (m *MockExternal) GetLowestBlockToDecide() idx.Block {
 	return ret0
 }
 
-// GetLowestBlockToDecide indicates an expected call of GetLowestBlockToDecide
+// GetLowestBlockToDecide indicates an expected call of GetLowestBlockToDecide.
 func (mr *MockExternalMockRecorder) GetLowestBlockToDecide() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLowestBlockToDecide", reflect.TypeOf((*MockExternal)(nil).GetLowestBlockToDecide))
 }
 
-// GetLowestEpochToDecide mocks base method
+// GetLowestEpochToDecide mocks base method.
 func (m *MockExternal) GetLowestEpochToDecide() idx.Epoch {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLowestEpochToDecide")
@@ -289,13 +288,13 @@ func (m *MockExternal) GetLowestEpochToDecide() idx.Epoch {
 	return ret0
 }
 
-// GetLowestEpochToDecide indicates an expected call of GetLowestEpochToDecide
+// GetLowestEpochToDecide indicates an expected call of GetLowestEpochToDecide.
 func (mr *MockExternalMockRecorder) GetLowestEpochToDecide() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLowestEpochToDecide", reflect.TypeOf((*MockExternal)(nil).GetLowestEpochToDecide))
 }
 
-// GetRules mocks base method
+// GetRules mocks base method.
 func (m *MockExternal) GetRules() opera.Rules {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRules")
@@ -303,13 +302,13 @@ func (m *MockExternal) GetRules() opera.Rules {
 	return ret0
 }
 
-// GetRules indicates an expected call of GetRules
+// GetRules indicates an expected call of GetRules.
 func (mr *MockExternalMockRecorder) GetRules() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRules", reflect.TypeOf((*MockExternal)(nil).GetRules))
 }
 
-// IsBusy mocks base method
+// IsBusy mocks base method.
 func (m *MockExternal) IsBusy() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsBusy")
@@ -317,13 +316,13 @@ func (m *MockExternal) IsBusy() bool {
 	return ret0
 }
 
-// IsBusy indicates an expected call of IsBusy
+// IsBusy indicates an expected call of IsBusy.
 func (mr *MockExternalMockRecorder) IsBusy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBusy", reflect.TypeOf((*MockExternal)(nil).IsBusy))
 }
 
-// IsSynced mocks base method
+// IsSynced mocks base method.
 func (m *MockExternal) IsSynced() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSynced")
@@ -331,25 +330,25 @@ func (m *MockExternal) IsSynced() bool {
 	return ret0
 }
 
-// IsSynced indicates an expected call of IsSynced
+// IsSynced indicates an expected call of IsSynced.
 func (mr *MockExternalMockRecorder) IsSynced() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSynced", reflect.TypeOf((*MockExternal)(nil).IsSynced))
 }
 
-// Lock mocks base method
+// Lock mocks base method.
 func (m *MockExternal) Lock() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Lock")
 }
 
-// Lock indicates an expected call of Lock
+// Lock indicates an expected call of Lock.
 func (mr *MockExternalMockRecorder) Lock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lock", reflect.TypeOf((*MockExternal)(nil).Lock))
 }
 
-// PeersNum mocks base method
+// PeersNum mocks base method.
 func (m *MockExternal) PeersNum() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PeersNum")
@@ -357,13 +356,13 @@ func (m *MockExternal) PeersNum() int {
 	return ret0
 }
 
-// PeersNum indicates an expected call of PeersNum
+// PeersNum indicates an expected call of PeersNum.
 func (mr *MockExternalMockRecorder) PeersNum() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeersNum", reflect.TypeOf((*MockExternal)(nil).PeersNum))
 }
 
-// Process mocks base method
+// Process mocks base method.
 func (m *MockExternal) Process(arg0 *inter.EventPayload) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Process", arg0)
@@ -371,48 +370,48 @@ func (m *MockExternal) Process(arg0 *inter.EventPayload) error {
 	return ret0
 }
 
-// Process indicates an expected call of Process
+// Process indicates an expected call of Process.
 func (mr *MockExternalMockRecorder) Process(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockExternal)(nil).Process), arg0)
 }
 
-// Unlock mocks base method
+// Unlock mocks base method.
 func (m *MockExternal) Unlock() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Unlock")
 }
 
-// Unlock indicates an expected call of Unlock
+// Unlock indicates an expected call of Unlock.
 func (mr *MockExternalMockRecorder) Unlock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockExternal)(nil).Unlock))
 }
 
-// MockTxPool is a mock of TxPool interface
+// MockTxPool is a mock of TxPool interface.
 type MockTxPool struct {
 	ctrl     *gomock.Controller
 	recorder *MockTxPoolMockRecorder
 }
 
-// MockTxPoolMockRecorder is the mock recorder for MockTxPool
+// MockTxPoolMockRecorder is the mock recorder for MockTxPool.
 type MockTxPoolMockRecorder struct {
 	mock *MockTxPool
 }
 
-// NewMockTxPool creates a new mock instance
+// NewMockTxPool creates a new mock instance.
 func NewMockTxPool(ctrl *gomock.Controller) *MockTxPool {
 	mock := &MockTxPool{ctrl: ctrl}
 	mock.recorder = &MockTxPoolMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTxPool) EXPECT() *MockTxPoolMockRecorder {
 	return m.recorder
 }
 
-// Count mocks base method
+// Count mocks base method.
 func (m *MockTxPool) Count() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Count")
@@ -420,13 +419,13 @@ func (m *MockTxPool) Count() int {
 	return ret0
 }
 
-// Count indicates an expected call of Count
+// Count indicates an expected call of Count.
 func (mr *MockTxPoolMockRecorder) Count() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockTxPool)(nil).Count))
 }
 
-// Has mocks base method
+// Has mocks base method.
 func (m *MockTxPool) Has(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Has", arg0)
@@ -434,13 +433,13 @@ func (m *MockTxPool) Has(arg0 common.Hash) bool {
 	return ret0
 }
 
-// Has indicates an expected call of Has
+// Has indicates an expected call of Has.
 func (mr *MockTxPoolMockRecorder) Has(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Has", reflect.TypeOf((*MockTxPool)(nil).Has), arg0)
 }
 
-// Pending mocks base method
+// Pending mocks base method.
 func (m *MockTxPool) Pending(arg0 bool) (map[common.Address]types.Transactions, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Pending", arg0)
@@ -449,50 +448,36 @@ func (m *MockTxPool) Pending(arg0 bool) (map[common.Address]types.Transactions, 
 	return ret0, ret1
 }
 
-// Pending indicates an expected call of Pending
+// Pending indicates an expected call of Pending.
 func (mr *MockTxPoolMockRecorder) Pending(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pending", reflect.TypeOf((*MockTxPool)(nil).Pending), arg0)
 }
 
-// SubscribeNewTxsNotify mocks base method
-func (m *MockTxPool) SubscribeNewTxsNotify(arg0 chan<- evmcore.NewTxsNotify) event.Subscription {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscribeNewTxsNotify", arg0)
-	ret0, _ := ret[0].(event.Subscription)
-	return ret0
-}
-
-// SubscribeNewTxsNotify indicates an expected call of SubscribeNewTxsNotify
-func (mr *MockTxPoolMockRecorder) SubscribeNewTxsNotify(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeNewTxsNotify", reflect.TypeOf((*MockTxPool)(nil).SubscribeNewTxsNotify), arg0)
-}
-
-// MockTxSigner is a mock of TxSigner interface
+// MockTxSigner is a mock of TxSigner interface.
 type MockTxSigner struct {
 	ctrl     *gomock.Controller
 	recorder *MockTxSignerMockRecorder
 }
 
-// MockTxSignerMockRecorder is the mock recorder for MockTxSigner
+// MockTxSignerMockRecorder is the mock recorder for MockTxSigner.
 type MockTxSignerMockRecorder struct {
 	mock *MockTxSigner
 }
 
-// NewMockTxSigner creates a new mock instance
+// NewMockTxSigner creates a new mock instance.
 func NewMockTxSigner(ctrl *gomock.Controller) *MockTxSigner {
 	mock := &MockTxSigner{ctrl: ctrl}
 	mock.recorder = &MockTxSignerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTxSigner) EXPECT() *MockTxSignerMockRecorder {
 	return m.recorder
 }
 
-// ChainID mocks base method
+// ChainID mocks base method.
 func (m *MockTxSigner) ChainID() *big.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainID")
@@ -500,13 +485,13 @@ func (m *MockTxSigner) ChainID() *big.Int {
 	return ret0
 }
 
-// ChainID indicates an expected call of ChainID
+// ChainID indicates an expected call of ChainID.
 func (mr *MockTxSignerMockRecorder) ChainID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockTxSigner)(nil).ChainID))
 }
 
-// Equal mocks base method
+// Equal mocks base method.
 func (m *MockTxSigner) Equal(arg0 types.Signer) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Equal", arg0)
@@ -514,13 +499,13 @@ func (m *MockTxSigner) Equal(arg0 types.Signer) bool {
 	return ret0
 }
 
-// Equal indicates an expected call of Equal
+// Equal indicates an expected call of Equal.
 func (mr *MockTxSignerMockRecorder) Equal(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Equal", reflect.TypeOf((*MockTxSigner)(nil).Equal), arg0)
 }
 
-// Hash mocks base method
+// Hash mocks base method.
 func (m *MockTxSigner) Hash(arg0 *types.Transaction) common.Hash {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Hash", arg0)
@@ -528,13 +513,13 @@ func (m *MockTxSigner) Hash(arg0 *types.Transaction) common.Hash {
 	return ret0
 }
 
-// Hash indicates an expected call of Hash
+// Hash indicates an expected call of Hash.
 func (mr *MockTxSignerMockRecorder) Hash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hash", reflect.TypeOf((*MockTxSigner)(nil).Hash), arg0)
 }
 
-// Sender mocks base method
+// Sender mocks base method.
 func (m *MockTxSigner) Sender(arg0 *types.Transaction) (common.Address, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sender", arg0)
@@ -543,13 +528,13 @@ func (m *MockTxSigner) Sender(arg0 *types.Transaction) (common.Address, error) {
 	return ret0, ret1
 }
 
-// Sender indicates an expected call of Sender
+// Sender indicates an expected call of Sender.
 func (mr *MockTxSignerMockRecorder) Sender(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sender", reflect.TypeOf((*MockTxSigner)(nil).Sender), arg0)
 }
 
-// SignatureValues mocks base method
+// SignatureValues mocks base method.
 func (m *MockTxSigner) SignatureValues(arg0 *types.Transaction, arg1 []byte) (*big.Int, *big.Int, *big.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignatureValues", arg0, arg1)
@@ -560,36 +545,36 @@ func (m *MockTxSigner) SignatureValues(arg0 *types.Transaction, arg1 []byte) (*b
 	return ret0, ret1, ret2, ret3
 }
 
-// SignatureValues indicates an expected call of SignatureValues
+// SignatureValues indicates an expected call of SignatureValues.
 func (mr *MockTxSignerMockRecorder) SignatureValues(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignatureValues", reflect.TypeOf((*MockTxSigner)(nil).SignatureValues), arg0, arg1)
 }
 
-// MockSigner is a mock of Signer interface
+// MockSigner is a mock of Signer interface.
 type MockSigner struct {
 	ctrl     *gomock.Controller
 	recorder *MockSignerMockRecorder
 }
 
-// MockSignerMockRecorder is the mock recorder for MockSigner
+// MockSignerMockRecorder is the mock recorder for MockSigner.
 type MockSignerMockRecorder struct {
 	mock *MockSigner
 }
 
-// NewMockSigner creates a new mock instance
+// NewMockSigner creates a new mock instance.
 func NewMockSigner(ctrl *gomock.Controller) *MockSigner {
 	mock := &MockSigner{ctrl: ctrl}
 	mock.recorder = &MockSignerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 	return m.recorder
 }
 
-// Sign mocks base method
+// Sign mocks base method.
 func (m *MockSigner) Sign(arg0 validatorpk.PubKey, arg1 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sign", arg0, arg1)
@@ -598,7 +583,7 @@ func (m *MockSigner) Sign(arg0 validatorpk.PubKey, arg1 []byte) ([]byte, error) 
 	return ret0, ret1
 }
 
-// Sign indicates an expected call of Sign
+// Sign indicates an expected call of Sign.
 func (mr *MockSignerMockRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockSigner)(nil).Sign), arg0, arg1)

--- a/gossip/emitter/world.go
+++ b/gossip/emitter/world.go
@@ -9,9 +9,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	notify "github.com/ethereum/go-ethereum/event"
 
-	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/opera"
 	"github.com/Fantom-foundation/go-opera/valkeystore"
@@ -83,10 +81,6 @@ type TxPool interface {
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
 	Pending(enforceTips bool) (map[common.Address]types.Transactions, error)
-
-	// SubscribeNewTxsNotify should return an event subscription of
-	// NewTxsNotify and send events to the given channel.
-	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
 
 	// Count returns the total number of transactions
 	Count() int

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -5,7 +5,9 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	notify "github.com/ethereum/go-ethereum/event"
 
+	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
@@ -102,6 +104,7 @@ var errorToString = map[int]string{
 
 type TxPool interface {
 	emitter.TxPool
+	SubscribeNewTxsNotify(chan<- evmcore.NewTxsNotify) notify.Subscription
 	// AddRemotes should add the given transactions to the pool.
 	AddRemotes([]*types.Transaction) []error
 	AddLocals(txs []*types.Transaction) []error

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -50,6 +50,7 @@ import (
 	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/Fantom-foundation/go-opera/logger"
 	"github.com/Fantom-foundation/go-opera/utils/signers/gsignercache"
+	"github.com/Fantom-foundation/go-opera/utils/txtime"
 	"github.com/Fantom-foundation/go-opera/utils/wgmutex"
 	"github.com/Fantom-foundation/go-opera/valkeystore"
 	"github.com/Fantom-foundation/go-opera/vecmt"
@@ -345,6 +346,7 @@ func (s *Service) EmitterWorld(signer valkeystore.SignerI) emitter.World {
 
 // RegisterEmitter must be called before service is started
 func (s *Service) RegisterEmitter(em *emitter.Emitter) {
+	txtime.Enabled = true // enable tracking of tx times
 	s.emitters = append(s.emitters, em)
 }
 

--- a/utils/txtime/txtime.go
+++ b/utils/txtime/txtime.go
@@ -10,13 +10,20 @@ import (
 var (
 	globalFinalized, _ = wlru.New(30000, 30000)
 	globalNonFinalized, _ = wlru.New(5000, 5000)
+	Enabled = false
 )
 
 func Saw(txid common.Hash, t time.Time) {
+	if !Enabled {
+		return
+	}
 	globalNonFinalized.ContainsOrAdd(txid, t, 1)
 }
 
 func Validated(txid common.Hash, t time.Time) {
+	if !Enabled {
+		return
+	}
 	v, has := globalNonFinalized.Peek(txid)
 	if has {
 		t = v.(time.Time)
@@ -25,6 +32,9 @@ func Validated(txid common.Hash, t time.Time) {
 }
 
 func Of(txid common.Hash) time.Time {
+	if !Enabled {
+		return time.Time{}
+	}
 	v, has := globalFinalized.Get(txid)
 	if has {
 		return v.(time.Time)

--- a/utils/txtime/txtime.go
+++ b/utils/txtime/txtime.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	globalFinalized, _ = wlru.New(30000, 30000)
+	globalFinalized, _    = wlru.New(30000, 30000)
 	globalNonFinalized, _ = wlru.New(5000, 5000)
-	Enabled = false
+	Enabled               = false
 )
 
 func Saw(txid common.Hash, t time.Time) {


### PR DESCRIPTION
- add global tracking of tx times instead of local emitter tracking, which allows to get timestamp right after receiving the tx