### PR TITLE
Emitter accepts adjustments from EmissionDriver contract

### DIFF
--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -52,6 +52,9 @@ func TestEmitter(t *testing.T) {
 	external.EXPECT().PeersNum().
 		Return(int(3)).
 		AnyTimes()
+	external.EXPECT().StateDB().
+		Return(nil).
+		AnyTimes()
 
 	em := NewEmitter(cfg, World{
 		External: external,

--- a/gossip/emitter/mock/world.go
+++ b/gossip/emitter/mock/world.go
@@ -16,6 +16,7 @@ import (
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	pos "github.com/Fantom-foundation/lachesis-base/inter/pos"
 	common "github.com/ethereum/go-ethereum/common"
+	state "github.com/ethereum/go-ethereum/core/state"
 	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -374,6 +375,20 @@ func (m *MockExternal) Process(arg0 *inter.EventPayload) error {
 func (mr *MockExternalMockRecorder) Process(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockExternal)(nil).Process), arg0)
+}
+
+// StateDB mocks base method.
+func (m *MockExternal) StateDB() *state.StateDB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateDB")
+	ret0, _ := ret[0].(*state.StateDB)
+	return ret0
+}
+
+// StateDB indicates an expected call of StateDB.
+func (mr *MockExternalMockRecorder) StateDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateDB", reflect.TypeOf((*MockExternal)(nil).StateDB))
 }
 
 // Unlock mocks base method.

--- a/gossip/emitter/world.go
+++ b/gossip/emitter/world.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/Fantom-foundation/go-opera/inter"
@@ -35,6 +36,8 @@ type (
 		IsBusy() bool
 		IsSynced() bool
 		PeersNum() int
+
+		StateDB() *state.StateDB
 	}
 
 	// aliases for mock generator

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/Fantom-foundation/go-opera/gossip/emitter"
@@ -58,6 +59,14 @@ func (ew *emitterWorldProc) DagIndex() *vecmt.Index {
 
 func (ew *emitterWorldProc) IsBusy() bool {
 	return atomic.LoadUint32(&ew.s.eventBusyFlag) != 0 || atomic.LoadUint32(&ew.s.blockBusyFlag) != 0
+}
+
+func (ew *emitterWorldProc) StateDB() *state.StateDB {
+	statedb, err := ew.s.store.evm.StateDB(ew.s.store.GetBlockState().FinalizedStateRoot)
+	if err != nil {
+		return nil
+	}
+	return statedb
 }
 
 func (ew *emitterWorldProc) IsSynced() bool {

--- a/opera/contracts/emitterdriver/emitterdriver.go
+++ b/opera/contracts/emitterdriver/emitterdriver.go
@@ -1,0 +1,6 @@
+package emitterdriver
+
+import "github.com/ethereum/go-ethereum/common"
+
+// ContractAddress is the EmitterDriver contract address
+var ContractAddress = common.HexToAddress("0xee00d10000000000000000000000000000000000")


### PR DESCRIPTION
- EmissionDriver is a special contract which signals validators to speed up or slow down emission, which allows to tune the parameters for better performance. Validators will accept adjustments only within the range (`cfg/4`, `cfg*20`), where `cfg` is a locally configured parameter
- EmissionDriver triggers switching to the new FC emission protocol, which replaces the the previous trigger `upgraded validators` > 5W/6