### PR TITLE
Feature/transient storage opcodes

### DIFF
--- a/evmcore/chain_makers.go
+++ b/evmcore/chain_makers.go
@@ -18,6 +18,7 @@ package evmcore
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/core"
 	"math/big"
 	"time"
 
@@ -78,7 +79,27 @@ func (b *BlockGen) SetCoinbase(addr common.Address) {
 // added. Notably, contract code relying on the BLOCKHASH instruction
 // will panic during execution.
 func (b *BlockGen) AddTx(tx *types.Transaction) {
-	b.AddTxWithChain(nil, tx)
+	b.addTx(nil, vm.Config{}, tx)
+}
+
+// addTx adds a transaction to the generated block. If no coinbase has
+// been set, the block's coinbase is set to the zero address.
+//
+// There are a few options can be passed as well in order to run some
+// customized rules.
+// - bc:       enables the ability to query historical block hashes for BLOCKHASH
+// - vmConfig: extends the flexibility for customizing evm rules, e.g. enable extra EIPs
+func (b *BlockGen) addTx(bc *core.BlockChain, vmConfig vm.Config, tx *types.Transaction) {
+	if b.gasPool == nil {
+		b.SetCoinbase(common.Address{})
+	}
+	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
+	receipt, err := core.ApplyTransaction(b.config, bc, &b.header.Coinbase, (*core.GasPool)(b.gasPool), b.statedb, b.header, tx, &b.header.GasUsed, vmConfig)
+	if err != nil {
+		panic(err)
+	}
+	b.txs = append(b.txs, tx)
+	b.receipts = append(b.receipts, receipt)
 }
 
 // AddTxWithChain adds a transaction to the generated block. If no coinbase has
@@ -97,7 +118,7 @@ func (b *BlockGen) AddTxWithChain(bc DummyChain, tx *types.Transaction) {
 	if err != nil {
 		panic(err)
 	}
-	b.statedb.Prepare(tx.Hash(), len(b.txs))
+	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
 	blockContext := NewEVMBlockContext(b.header, bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, b.statedb, b.config, opera.DefaultVMConfig)
 	receipt, _, _, err := applyTransaction(msg, b.config, b.gasPool, b.statedb, b.header.Number, b.header.Hash, tx, &b.header.GasUsed, vmenv, func(log *types.Log, db *state.StateDB) {})
@@ -106,6 +127,10 @@ func (b *BlockGen) AddTxWithChain(bc DummyChain, tx *types.Transaction) {
 	}
 	b.txs = append(b.txs, tx)
 	b.receipts = append(b.receipts, receipt)
+}
+
+func (b *BlockGen) AddTxWithVMConfig(tx *types.Transaction, config vm.Config) {
+	b.addTx(nil, config, tx)
 }
 
 // GetBalance returns the balance of the given address at the generated block.

--- a/evmcore/state_prefetcher.go
+++ b/evmcore/state_prefetcher.go
@@ -66,7 +66,7 @@ func (p *statePrefetcher) Prefetch(block *EvmBlock, statedb *state.StateDB, cfg 
 		if err != nil {
 			return // Also invalid block, bail out
 		}
-		statedb.Prepare(tx.Hash(), i)
+		statedb.SetTxContext(tx.Hash(), i)
 		if err := precacheTransaction(msg, p.config, gaspool, statedb, header, evm); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -161,6 +161,22 @@ func applyTransaction(
 	return receipt, result.UsedGas, false, err
 }
 
+// ApplyTransaction attempts to apply a transaction to the given state database
+// and uses the input parameters for its environment. It returns the receipt
+// for the transaction, gas used and an error if the transaction failed,
+// indicating the block was invalid.
+func ApplyTransaction(config *params.ChainConfig, bc DummyChain, author *common.Address, gp *GasPool, statedb *state.StateDB, header *EvmHeader, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), header.BaseFee)
+	if err != nil {
+		return nil, err
+	}
+	// Create a new context to be used in the EVM environment
+	blockContext := NewEVMBlockContext(header, bc, author)
+	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
+	receipt, _, _, err := applyTransaction(msg, config, gp, statedb, header.Number, header.Hash, tx, usedGas, vmenv, func(log *types.Log, db *state.StateDB) {})
+	return receipt, err
+}
+
 func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (types.Message, error) {
 	if !internaltx.IsInternal(tx) {
 		return tx.AsMessage(signer, baseFee)

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -79,7 +79,7 @@ func (p *StateProcessor) Process(
 			return nil, nil, nil, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 
-		statedb.Prepare(tx.Hash(), i)
+		statedb.SetTxContext(tx.Hash(), i)
 		receipt, _, skip, err = applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv, onNewLog)
 		if skip {
 			skipped = append(skipped, uint32(i))


### PR DESCRIPTION
all: implement EIP-1153 transient storage Implements TSTORE and TLOAD as specified by the following EIP:
- https://eips.ethereum.org/EIPS/eip-1153
- https://ethereum-magicians.org/t/eip-1153-transient-storage-opcodes/553

It is necessary to activate this functionality by commenting out the line (line 73) in the core/vm/jump_table.go file.

There is no additional standard EIP-4399 (prerandao) in the implementation, since there is no need to track the implementation without PoS in the go-opera system.