### PR TITLE
Remove redundant DefaultDataDir call

### DIFF
--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -563,7 +563,6 @@ func defaultNodeConfig() node.Config {
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "ftm", "dag", "abft", "web3")
 	cfg.WSModules = append(cfg.WSModules, "eth", "ftm", "dag", "abft", "web3")
 	cfg.IPCPath = "opera.ipc"
-	cfg.DataDir = DefaultDataDir()
 	return cfg
 }
 

--- a/cmd/opera/launcher/config.go
+++ b/cmd/opera/launcher/config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/naoina/toml"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"gopkg.in/urfave/cli.v1"
@@ -486,7 +485,7 @@ func mayMakeAllConfigs(ctx *cli.Context) (*config, error) {
 	// Defaults (low priority)
 	cacheRatio := cacheScaler(ctx)
 	cfg := config{
-		Node:          defaultNodeConfig(),
+		Node:          DefaultNodeConfig(),
 		Opera:         gossip.DefaultConfig(cacheRatio),
 		Emitter:       emitter.DefaultConfig(),
 		TxPool:        evmcore.DefaultTxPoolConfig,
@@ -553,16 +552,6 @@ func makeAllConfigs(ctx *cli.Context) *config {
 	if err != nil {
 		utils.Fatalf("%v", err)
 	}
-	return cfg
-}
-
-func defaultNodeConfig() node.Config {
-	cfg := NodeDefaultConfig
-	cfg.Name = clientIdentifier
-	cfg.Version = params.VersionWithCommit(gitCommit, gitDate)
-	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "ftm", "dag", "abft", "web3")
-	cfg.WSModules = append(cfg.WSModules, "eth", "ftm", "dag", "abft", "web3")
-	cfg.IPCPath = "opera.ipc"
 	return cfg
 }
 

--- a/cmd/opera/launcher/config_custom_test.go
+++ b/cmd/opera/launcher/config_custom_test.go
@@ -22,7 +22,7 @@ func TestConfigFile(t *testing.T) {
 	}
 
 	src := config{
-		Node:          defaultNodeConfig(),
+		Node:          DefaultNodeConfig(),
 		Opera:         gossip.DefaultConfig(cacheRatio),
 		Emitter:       emitter.DefaultConfig(),
 		TxPool:        evmcore.DefaultTxPoolConfig,

--- a/cmd/opera/launcher/defaults.go
+++ b/cmd/opera/launcher/defaults.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/nat"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -28,22 +29,27 @@ func overrideFlags() {
 }
 
 // NodeDefaultConfig contains reasonable default settings.
-var NodeDefaultConfig = node.Config{
-	DataDir:             DefaultDataDir(),
-	HTTPPort:            DefaultHTTPPort,
-	HTTPModules:         []string{},
-	HTTPVirtualHosts:    []string{"localhost"},
-	HTTPTimeouts:        rpc.DefaultHTTPTimeouts,
-	WSPort:              DefaultWSPort,
-	WSModules:           []string{},
-	GraphQLVirtualHosts: []string{"localhost"},
-	P2P: p2p.Config{
-		NoDiscovery: false, // enable discovery v4 by default
-		DiscoveryV5: true,  // enable discovery v5 by default
-		ListenAddr:  fmt.Sprintf(":%d", DefaultP2PPort),
-		MaxPeers:    50,
-		NAT:         nat.Any(),
-	},
+func DefaultNodeConfig() node.Config {
+	return node.Config{
+		DataDir:             DefaultDataDir(),
+		HTTPPort:            DefaultHTTPPort,
+		HTTPTimeouts:        rpc.DefaultHTTPTimeouts,
+		HTTPVirtualHosts:    []string{"localhost"},
+		HTTPModules:         []string{"eth", "ftm", "dag", "abft", "web3"},
+		WSModules:           []string{"eth", "ftm", "dag", "abft", "web3"},
+		WSPort:              DefaultWSPort,
+		GraphQLVirtualHosts: []string{"localhost"},
+		P2P: p2p.Config{
+			NoDiscovery: false, // enable discovery v4 by default
+			DiscoveryV5: true,  // enable discovery v5 by default
+			ListenAddr:  fmt.Sprintf(":%d", DefaultP2PPort),
+			MaxPeers:    50,
+			NAT:         nat.Any(),
+		},
+		Name:    clientIdentifier,
+		Version: params.VersionWithCommit(gitCommit, gitDate),
+		IPCPath: "opera.ipc",
+	}
 }
 
 // DefaultDataDir is the default data directory to use for the databases and other

--- a/cmd/opera/launcher/defaults.go
+++ b/cmd/opera/launcher/defaults.go
@@ -28,7 +28,7 @@ func overrideFlags() {
 	utils.WSPortFlag.Value = DefaultWSPort
 }
 
-// NodeDefaultConfig contains reasonable default settings.
+// DefaultNodeConfig creates reasonable default configuration settings
 func DefaultNodeConfig() node.Config {
 	return node.Config{
 		DataDir:             DefaultDataDir(),

--- a/cmd/opera/launcher/run_test.go
+++ b/cmd/opera/launcher/run_test.go
@@ -33,7 +33,7 @@ type testcli struct {
 }
 
 func (tt *testcli) readConfig() {
-	cfg := defaultNodeConfig()
+	cfg := DefaultNodeConfig()
 	cfg.DataDir = tt.Datadir
 	addr := common.Address{} // TODO: addr = emitter coinbase
 	tt.Coinbase = strings.ToLower(addr.String())


### PR DESCRIPTION
The `DefaultDataDir()` call is already assigned in the `NodeDefaultConfig` global variable on line 32 in `defaults.go`