### PR TITLE
Remove duplicated condition for useless peers

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -788,10 +788,6 @@ func (h *handler) handle(p *peer) error {
 		useless = true
 		discfilter.Ban(p.ID())
 	}
-	if !p.Peer.Info().Network.Trusted && useless && h.peers.UselessNum() >= h.maxPeers/10 {
-		// don't allow more than 10% of useless peers
-		return p2p.DiscTooManyPeers
-	}
 	if !p.Peer.Info().Network.Trusted && useless {
 		if h.peers.UselessNum() >= h.maxPeers/10 {
 			// don't allow more than 10% of useless peers


### PR DESCRIPTION
This condition is duplicated at the directly following lines and can be removed with no change in the behavior.

@uprendis 