### PR TITLE
Run github action on PRs too

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,11 @@
 name: Check build
 
-on: [push]
+on: 
+  push:
+  pull_request:
+    branches: 
+      - develop
+      - master
 
 jobs:
   check-build:


### PR DESCRIPTION
Until now the test_build action would only run on direct pushes to branches.

This PR adds the test runs also when PRs are issued to `develop` and `master`.

This is especially helpful when PRs are issued from forks, as then we wouldn't see the test results because the push was done on the fork.