### PR TITLE
API: Randomize output of eth_feeHistory to mimic ETH API

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -90,6 +90,7 @@ type feeHistoryResult struct {
 	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
 	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
 	GasUsedRatio []float64        `json:"gasUsedRatio"`
+	Note         string           `json:"note"`
 }
 
 var errInvalidPercentile = errors.New("invalid reward percentile")
@@ -153,6 +154,11 @@ func (s *PublicEthereumAPI) FeeHistory(ctx context.Context, blockCount rpc.Decim
 		r := rand.New(rand.NewSource(int64(oldest) + int64(i)))
 		res.GasUsedRatio = append(res.GasUsedRatio, 0.9+r.Float64()*0.1)
 	}
+	res.Note = `In the FTM network, the eth_feeHistory method operates slightly differently due to the network's unique consensus mechanism. ` +
+		`Here, instead of returning a range of gas tip values from requested blocks, ` +
+		`it provides a singular estimated gas tip based on a defined confidence level (indicated by the percentile parameter). ` +
+		`This approach means that while you will receive replicated (and randomized) reward values across the requested blocks, ` +
+		`the average or median of these values remains consistent with the intended gas tip.`
 	return res, nil
 }
 


### PR DESCRIPTION
In ETH API, `eth_feeHistory` is originally intended to return the history of `gas tip`s in recent blocks, which has to be used as a data source for a custom `gas tip` estimation. Typically, the resulting `gas tip` is expected to be an average or a median of the historic median values.
The same approach cannot be used in FTM due to the leaderless and asynchronous nature of the consensus algorithm. Instead, `eth_feeHistory` itself performs the estimation of `gas tip` and calculates a single `gas tip`, where `percentile` is interpreted as a confidence level (higher -> larger fee). This value is then copied for each requested block, in a case if multiple blocks were requested.
We expect that users can reuse the same code for `gas tip` estimation which they use for ETH, because both an average or a median of the copied values will still be equal to the intended value. However, it causes a confusion as it's apparent that the output doesn't match the ETH API description of the method.

This PR randomizes the copied `gas tip` by up to 2% upward in order to closer cosmetically mimic the original ETH API variant of the method. The `gas tip` for last requested block is left as-is without randomization.
The PR adds note to output of eth_feeHistory which explains the difference in output.

This way, we endeavor to balance fidelity to the original API design with the adaptations necessary for FTM's unique architecture, thereby providing users with a tool that is both familiar and optimized for the new context.