### PR TITLE
Fix of trusted testnet genesis preset list

### DIFF
--- a/cmd/opera/launcher/params.go
+++ b/cmd/opera/launcher/params.go
@@ -182,7 +182,7 @@ var (
 
 		{
 			Name:   "Testnet-16200 without history",
-			Header: mainnetHeader,
+			Header: testnetHeader,
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
@@ -190,7 +190,7 @@ var (
 		},
 		{
 			Name:   "Testnet-16200 without MPT",
-			Header: mainnetHeader,
+			Header: testnetHeader,
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0x61040a80f16755b86d67f13880f55c1238d307e2e1c6fc87951eb3bdee0bdff2"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x12010621d8cf4dcd4ea357e98eac61edf9517a6df752cb2d929fca69e56bd8d1"),
@@ -200,7 +200,7 @@ var (
 		},
 		{
 			Name:   "Testnet-16200 with pruned MPT",
-			Header: mainnetHeader,
+			Header: testnetHeader,
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0x61040a80f16755b86d67f13880f55c1238d307e2e1c6fc87951eb3bdee0bdff2"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x12010621d8cf4dcd4ea357e98eac61edf9517a6df752cb2d929fca69e56bd8d1"),

--- a/cmd/opera/launcher/params.go
+++ b/cmd/opera/launcher/params.go
@@ -184,8 +184,8 @@ var (
 			Name:   "Testnet-16200 without history",
 			Header: testnetHeader,
 			Hashes: genesis.Hashes{
-				genesisstore.EpochsSection(0): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
-				genesisstore.BlocksSection(0): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.EpochsSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.BlocksSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
 			},
 		},
 		{
@@ -194,8 +194,8 @@ var (
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0x61040a80f16755b86d67f13880f55c1238d307e2e1c6fc87951eb3bdee0bdff2"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x12010621d8cf4dcd4ea357e98eac61edf9517a6df752cb2d929fca69e56bd8d1"),
-				genesisstore.EpochsSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
-				genesisstore.BlocksSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.EpochsSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.BlocksSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
 			},
 		},
 		{
@@ -204,8 +204,8 @@ var (
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0x61040a80f16755b86d67f13880f55c1238d307e2e1c6fc87951eb3bdee0bdff2"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x12010621d8cf4dcd4ea357e98eac61edf9517a6df752cb2d929fca69e56bd8d1"),
-				genesisstore.EpochsSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
-				genesisstore.BlocksSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.EpochsSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.BlocksSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
 				genesisstore.EvmSection(0):    hash.HexToHash("0xbd66dcbbe77881d5aae5091ee9c455d213cebef2cc53c0d4bb356840c7020f7b"),
 			},
 		},
@@ -215,8 +215,8 @@ var (
 			Hashes: genesis.Hashes{
 				genesisstore.EpochsSection(0): hash.HexToHash("0x61040a80f16755b86d67f13880f55c1238d307e2e1c6fc87951eb3bdee0bdff2"),
 				genesisstore.BlocksSection(0): hash.HexToHash("0x12010621d8cf4dcd4ea357e98eac61edf9517a6df752cb2d929fca69e56bd8d1"),
-				genesisstore.EpochsSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
-				genesisstore.BlocksSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.EpochsSection(1): hash.HexToHash("0x7d651ed0e0f3e92ffd89cb52112598db54afd8bf3050bc083ff0bfe1b98948fd"),
+				genesisstore.BlocksSection(1): hash.HexToHash("0xd72e9bf39c645df8d978955fab8997a7e9cd7cb5812c007e2bb4b51a8c570a90"),
 				genesisstore.EvmSection(0):    hash.HexToHash("0x9227c80bf56e4af08dc32cb6043cc43672f2be8177d550ab34a7a9f57f4f104b"),
 				genesisstore.EvmSection(1):    hash.HexToHash("0x2376016f7ba13123244c6b56088a76e2e8bd5d5795fa92bad65f61488d12c236"),
 			},

--- a/opera/genesis/types.go
+++ b/opera/genesis/types.go
@@ -1,6 +1,10 @@
 package genesis
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/Fantom-foundation/lachesis-base/hash"
 
 	"github.com/Fantom-foundation/go-opera/inter/ibr"
@@ -45,6 +49,19 @@ func (hh Hashes) Equal(hh2 Hashes) bool {
 	return hh.Includes(hh2) && hh2.Includes(hh)
 }
 
+func (hh Hashes) String() string {
+	bb := make([]string, 0, len(hh))
+	for n, h := range hh {
+		bb = append(bb, fmt.Sprintf("%s: %s", n, h.String()))
+	}
+	sort.Strings(bb)
+	return "{" + strings.Join(bb, ", ") + "}"
+}
+
 func (h Header) Equal(h2 Header) bool {
 	return h == h2
+}
+
+func (h Header) String() string {
+	return fmt.Sprintf("{%d, net:%s, id:%s}", h.NetworkID, h.NetworkName, h.GenesisID.String())
 }


### PR DESCRIPTION
Fix of mistyping which leads to
`Genesis file doesn't refer to any trusted preset. Enable experimental genesis with --genesis.allowExperimental
`fatal log on start with [official](https://github.com/Fantom-foundation/lachesis_launch/blob/master/docs/genesis-files.md#epoch-16200-block-12262196) genesis files.