### PR TITLE
Datadir symlinks cache

### DIFF
--- a/cmd/opera/launcher/launcher.go
+++ b/cmd/opera/launcher/launcher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	gmetrics "github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/discover/discfilter"
 	"github.com/ethereum/go-ethereum/params"
@@ -301,9 +300,7 @@ func makeNode(ctx *cli.Context, cfg *config, genesisStore *genesisstore.Store) (
 		_ = genesisStore.Close()
 	}
 
-	if gmetrics.Enabled {
-		metrics.SetDataDir(cfg.Node.DataDir)
-	}
+	metrics.SetDataDir(cfg.Node.DataDir)
 	memorizeDBPreset(cfg)
 
 	// substitute default bootnodes if requested

--- a/cmd/opera/launcher/metrics/metrics.go
+++ b/cmd/opera/launcher/metrics/metrics.go
@@ -47,7 +47,7 @@ func measureDbDir(name, datadir string) {
 
 var (
 	symlinksCache     = make(map[string]string, 10e6)
-	symlinksThrottler = &throttler{Period: 100, Timeout: 100 * time.Millisecond}
+	symlinksThrottler = &throttler{Period: 1000, Timeout: 100 * time.Millisecond}
 )
 
 func sizeOfDir(dir string) (size int64) {

--- a/cmd/opera/launcher/metrics/metrics_test.go
+++ b/cmd/opera/launcher/metrics/metrics_test.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"testing"
+)
+
+func BenchmarkSizeOfDir(b *testing.B) {
+	var (
+		datadir = "~/.opera"
+		size    int64
+	)
+
+	symlinksThrottler = new(throttler) // disabled throttling
+	size = sizeOfDir(datadir)          // cache warming
+	b.ResetTimer()
+
+	for i := 0; i < (b.N * 10); i++ {
+		size = sizeOfDir(datadir)
+	}
+	b.Log(size)
+}

--- a/cmd/opera/launcher/metrics/throttler.go
+++ b/cmd/opera/launcher/metrics/throttler.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"time"
+)
+
+type throttler struct {
+	Period  uint
+	Timeout time.Duration
+	count   uint
+}
+
+func (t *throttler) Do() {
+	if t.Period == 0 {
+		return
+	}
+
+	t.count++
+	if t.count%t.Period == 0 {
+		time.Sleep(t.Timeout)
+	}
+}


### PR DESCRIPTION
Datadir size measurement is ~7 times faster with cached `filepath.EvalSymlinks()`.

Benchmark results (see `./cmd/opera/launcher/metrics/metrics_test.go`) of 400Gb datadir:

|              |  ns per op        | bytes per op   | allocs per op |
| ---------- | -------------------- | -------------------- |  --------------- |
| Before: |  28363077808 | 13015784248 | 156690205 |
| After:    |    4823172318 |   1477883992 |    11329437 |