### PR TITLE
Fix: network id handshake

### DIFF
--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -541,7 +541,7 @@ func (p *peer) readStatus(network uint64, handshake *handshakeData, genesis comm
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	// TODO: rm after all the nodes updated to #184
+	// TODO: rm after all the nodes updated to #527
 	if handshake.NetworkID == 0 {
 		handshake.NetworkID = network
 	}

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -494,7 +494,7 @@ func (p *peer) Handshake(network uint64, progress PeerProgress, genesis common.H
 		// send both HandshakeMsg and ProgressMsg
 		err := p2p.Send(p.rw, HandshakeMsg, &handshakeData{
 			ProtocolVersion: uint32(p.version),
-			NetworkID:       0, // TODO: set to `network` after all nodes updated to #184
+			NetworkID:       network,
 			Genesis:         genesis,
 		})
 		if err != nil {


### PR DESCRIPTION
First stage of fix.
Second stage (see `gossip/peer.readStatus()` todo) should be after all nodes upgrade.

Tested on mainnet.